### PR TITLE
NP-4135 Add Api Base

### DIFF
--- a/RemoveHydrogens.py
+++ b/RemoveHydrogens.py
@@ -25,13 +25,11 @@ class RemoveHydrogens(nanome.PluginInstance):
     def on_workspace_received(self, workspace):
         for complex in workspace.complexes:
             count = 0
-            for molecule in complex.molecules:
-                for chain in molecule.chains:
-                    for residue in chain.residues:
-                        for i in range(len(residue.atoms) - 1, -1, -1):
-                            if RemoveHydrogens._should_be_removed(residue.atoms[i]): # If this atom is an H, delete it
-                                count += 1
-                                del residue.atoms[i]
+            for residue in complex.residues:
+                for i in range(len(residue._atoms) - 1, -1, -1):
+                    if RemoveHydrogens._should_be_removed(residue._atoms[i]): # If this atom is an H, delete it
+                        count += 1
+                        del residue._atoms[i]
             Logs.debug(count, "hydrogens removed for", complex.molecular.name)
         self.update_workspace(workspace) # Update Nanome workspace, in "deep" mode
         

--- a/nanome/_internal/_network/_commands/_serialization/_position_structures.py
+++ b/nanome/_internal/_network/_commands/_serialization/_position_structures.py
@@ -26,14 +26,14 @@ class _PositionStructures(_TypeSerializer):
 
         for val in value:
             if isinstance(val, _Atom):
-                atom_ids.append(val.index)
+                atom_ids.append(val._index)
             elif isinstance(val, _Bond):
-                atom_ids.append(val._atom1.index)
-                atom_ids.append(val._atom2.index)
+                atom_ids.append(val._atom1._index)
+                atom_ids.append(val._atom2._index)
             #all other base objects implement the atoms generator
             elif isinstance(val, _Base):
                 for atom in val.atoms:
-                    atom_ids.append(atom.index)
+                    atom_ids.append(atom._index)
 
         context.write_using_serializer(self.array_serializer, atom_ids)
 

--- a/nanome/_internal/_structure/_base.py
+++ b/nanome/_internal/_structure/_base.py
@@ -1,4 +1,4 @@
 __metaclass__ = type
 class _Base(object):
     def __init__(self):
-        self.index = -1
+        self._index = -1

--- a/nanome/_internal/_structure/_io/_sdf/save.py
+++ b/nanome/_internal/_structure/_io/_sdf/save.py
@@ -48,7 +48,7 @@ def to_file(path, complex, options=None):
         for chain in chains:
             for residue in chain._residues:
                 for atom in residue.atoms:
-                    serial_by_atom_index[atom.index] = atom_serial
+                    serial_by_atom_index[atom._index] = atom_serial
                     saved_atom = Results.SavedAtom()
                     saved_atom.serial = atom_serial
                     saved_atom.atom = atom
@@ -60,10 +60,10 @@ def to_file(path, complex, options=None):
             if (options.write_bonds) or (options.write_het_bonds and chain.molecular._name[0] == 'H'):
                 for residue in chain._residues:
                     for bond in residue._bonds:
-                        if bond.atom1.index in serial_by_atom_index and bond.atom2.index in serial_by_atom_index:
+                        if bond.atom1._index in serial_by_atom_index and bond.atom2._index in serial_by_atom_index:
                             saved_bond = Results.SavedBond()
-                            saved_bond.serial_atom1 = serial_by_atom_index[bond.atom1.index]
-                            saved_bond.serial_atom2 = serial_by_atom_index[bond.atom2.index]
+                            saved_bond.serial_atom1 = serial_by_atom_index[bond.atom1._index]
+                            saved_bond.serial_atom2 = serial_by_atom_index[bond.atom2._index]
                             saved_bond.bond = bond
                             result.saved_bonds.append(saved_bond)
                             number_bonds += 1

--- a/nanome/_internal/_structure/_serialization/_atom_serializer.py
+++ b/nanome/_internal/_structure/_serialization/_atom_serializer.py
@@ -15,7 +15,7 @@ class _AtomSerializer(_TypeSerializer):
         return "Atom"
 
     def serialize(self, version, value, context):
-        context.write_long(value.index)
+        context.write_long(value._index)
         context.write_bool(value._rendering._selected)
         context.write_int(value._rendering._atom_mode)
         context.write_bool(value._rendering._labeled)
@@ -45,7 +45,7 @@ class _AtomSerializer(_TypeSerializer):
         atom = _Atom._create()
         index = context.read_long()
         if index >= 0:
-            atom.index = index
+            atom._index = index
         atom._rendering._selected = context.read_bool()
         atom_mode = context.read_int()
         atom._rendering._atom_mode = _Atom.AtomRenderingMode(atom_mode)

--- a/nanome/_internal/_structure/_serialization/_bond_serializer.py
+++ b/nanome/_internal/_structure/_serialization/_bond_serializer.py
@@ -15,7 +15,7 @@ class _BondSerializer(_TypeSerializer):
         return "Bond"
 
     def serialize(self, version, value, context):
-        context.write_long(value.index)
+        context.write_long(value._index)
 
         context.write_int(value._molecular._kind)
         #nothing to do with shallow yet 
@@ -25,7 +25,7 @@ class _BondSerializer(_TypeSerializer):
     def deserialize(self, version, context):
         # type: (_Atom, _ContextDeserialization) -> _Bond
         bond = _Bond._create()
-        bond.index = context.read_long()
+        bond._index = context.read_long()
 
         kind = context.read_int()
         bond._molecular._kind = _Bond.Kind(kind)

--- a/nanome/_internal/_structure/_serialization/_chain_serializer.py
+++ b/nanome/_internal/_structure/_serialization/_chain_serializer.py
@@ -18,7 +18,7 @@ class _ChainSerializer(_TypeSerializer):
         return "Chain"
 
     def serialize(self, version, value, context):
-        context.write_long(value.index)
+        context.write_long(value._index)
         if (self.shallow):
             context.write_using_serializer(self.array_serializer, [])
         else:
@@ -27,7 +27,7 @@ class _ChainSerializer(_TypeSerializer):
 
     def deserialize(self, version, context):
         chain = _Chain._create()
-        chain.index = context.read_long()
+        chain._index = context.read_long()
 
         chain._residues = context.read_using_serializer(self.array_serializer)
         chain._molecular._name = context.read_using_serializer(self.string)

--- a/nanome/_internal/_structure/_serialization/_complex_serializer.py
+++ b/nanome/_internal/_structure/_serialization/_complex_serializer.py
@@ -23,7 +23,7 @@ class _ComplexSerializer(_TypeSerializer):
         return "Complex"
 
     def serialize(self, version, value, context):
-        context.write_long(value.index)
+        context.write_long(value._index)
         if (self.shallow):
             context.write_using_serializer(self.array, [])
         else:
@@ -42,7 +42,7 @@ class _ComplexSerializer(_TypeSerializer):
 
     def deserialize(self, version, context):
         complex = _Complex._create()
-        complex.index = context.read_long()
+        complex._index = context.read_long()
 
         complex._molecules = context.read_using_serializer(self.array)
         complex._rendering._boxed = context.read_bool()

--- a/nanome/_internal/_structure/_serialization/_molecule_serializer.py
+++ b/nanome/_internal/_structure/_serialization/_molecule_serializer.py
@@ -20,7 +20,7 @@ class _MoleculeSerializer(_TypeSerializer):
         return "Molecule"
 
     def serialize(self, version, value, context):
-        context.write_long(value.index)
+        context.write_long(value._index)
 
         if (self.shallow):
             context.write_using_serializer(self.array, [])
@@ -32,7 +32,7 @@ class _MoleculeSerializer(_TypeSerializer):
 
     def deserialize(self, version, context):
         molecule = _Molecule._create()
-        molecule.index = context.read_long()
+        molecule._index = context.read_long()
 
         molecule._chains = context.read_using_serializer(self.array)
         molecule._molecular._name = context.read_using_serializer(self.string)

--- a/nanome/_internal/_structure/_serialization/_residue_serializer.py
+++ b/nanome/_internal/_structure/_serialization/_residue_serializer.py
@@ -21,7 +21,7 @@ class _ResidueSerializer(_TypeSerializer):
         return "Residue"
 
     def serialize(self, version, value, context):
-        context.write_long(value.index)
+        context.write_long(value._index)
 
         self.array.set_type(self.atom)
         if (self.shallow):
@@ -46,7 +46,7 @@ class _ResidueSerializer(_TypeSerializer):
 
     def deserialize(self, version, context):
         residue = _Residue._create()
-        residue.index = context.read_long()
+        residue._index = context.read_long()
 
         self.array.set_type(self.atom)
         residue._atoms = context.read_using_serializer(self.array)

--- a/nanome/api/structure/__init__.py
+++ b/nanome/api/structure/__init__.py
@@ -1,4 +1,5 @@
 from . import *
+from .base import Base
 from .atom import Atom
 from .bond import Bond
 from .residue import Residue

--- a/nanome/api/structure/atom.py
+++ b/nanome/api/structure/atom.py
@@ -1,7 +1,8 @@
 from nanome._internal._structure._atom import _Atom
 from nanome.util import Vector3, Color
+from . import Base
 
-class Atom(_Atom):
+class Atom(_Atom, Base):
     """    
     Represents an Atom
 
@@ -12,7 +13,7 @@ class Atom(_Atom):
     """
 
     def __init__(self):
-        _Atom.__init__(self)
+        super(Atom, self).__init__()
         self.rendering = self._rendering
         self.molecular = self._molecular
 

--- a/nanome/api/structure/base.py
+++ b/nanome/api/structure/base.py
@@ -1,0 +1,16 @@
+from nanome._internal._structure._base import _Base
+
+__metaclass__ = type
+
+
+class Base(_Base):
+    def __init__(self):
+        _Base.__init__(self)
+
+    @property
+    def index(self):
+        return self._index
+
+    @index.setter
+    def index(self, value):
+        self._index = value

--- a/nanome/api/structure/base.py
+++ b/nanome/api/structure/base.py
@@ -1,11 +1,9 @@
 from nanome._internal._structure._base import _Base
-
 __metaclass__ = type
-
 
 class Base(_Base):
     def __init__(self):
-        _Base.__init__(self)
+        super(Base, self).__init__()
 
     @property
     def index(self):

--- a/nanome/api/structure/bond.py
+++ b/nanome/api/structure/bond.py
@@ -1,6 +1,7 @@
 from nanome._internal._structure._bond import _Bond
+from . import Base
 
-class Bond(_Bond):
+class Bond(_Bond, Base):
     """    
     Represents a Bond between two atoms
 
@@ -9,7 +10,7 @@ class Bond(_Bond):
     """
 
     def __init__(self):
-        _Bond.__init__(self)
+        super(Bond, self).__init__()
         self.molecular = self._molecular
 
     @property

--- a/nanome/api/structure/chain.py
+++ b/nanome/api/structure/chain.py
@@ -1,8 +1,9 @@
 from nanome._internal._structure._chain import _Chain
+from . import Base
 
-class Chain(_Chain):
+class Chain(_Chain, Base):
     def __init__(self):
-        _Chain.__init__(self)
+        super(Chain, self).__init__()
         self.molecular = self._molecular
 
     def add_residue(self, residue):

--- a/nanome/api/structure/complex.py
+++ b/nanome/api/structure/complex.py
@@ -1,10 +1,12 @@
 from nanome._internal._structure._complex import _Complex
 from nanome.util import Vector3, Quaternion
 from .io import ComplexIO
-class Complex(_Complex):
+from . import Base
+
+class Complex(_Complex, Base):
     io = ComplexIO()
     def __init__(self):
-        _Complex.__init__(self)
+        super(Complex, self).__init__()
         self.rendering = self._rendering
         self.molecular = self._molecular
         self.transform = self._transform

--- a/nanome/api/structure/molecule.py
+++ b/nanome/api/structure/molecule.py
@@ -1,9 +1,9 @@
 from nanome._internal._structure._molecule import _Molecule
+from . import Base
 
-
-class Molecule(_Molecule):
+class Molecule(_Molecule, Base):
     def __init__(self):
-        _Molecule.__init__(self)
+        super(Molecule, self).__init__()
         self.molecular = self._molecular
         
     def add_chain(self, chain):

--- a/nanome/api/structure/residue.py
+++ b/nanome/api/structure/residue.py
@@ -1,8 +1,9 @@
 from nanome._internal._structure._residue import _Residue
+from . import Base
 
-class Residue(_Residue):
+class Residue(_Residue, Base):
     def __init__(self):
-        _Residue.__init__(self)
+        super(Residue, self).__init__()
         self.rendering = self._rendering
         self.molecular = self._molecular
 


### PR DESCRIPTION
Added the api.base.Base class to be a common inheritance for all structures. Added a property wrapper for index. renamed the old index to _index. Updated all uses to use the appropriate index access level.