### PR TITLE
Add verbose mode

### DIFF
--- a/nanome/_internal/_network/_net_instance.py
+++ b/nanome/_internal/_network/_net_instance.py
@@ -32,7 +32,7 @@ class _NetInstance(object):
         try:
             self._connection.connect((host, port))
             self._connection.setblocking(False)
-            Logs.debug("Connected to server", host, port)
+            Logs.message("Connected to server", host, port)
         except (ssl.SSLError, socket.error) as e:
             self._socket = None
             self._context = None

--- a/nanome/_internal/_plugin.py
+++ b/nanome/_internal/_plugin.py
@@ -15,6 +15,7 @@ class _Plugin(object):
     _plugin_id = -1
 
     def __parse_args(self):
+        Logs.set_verbose(False)
         for i in range(1, len(sys.argv)):
             if sys.argv[i] == "-h":
                 Logs.message("Usage:", sys.argv[1],"[-h] [-a ADDRESS] [-p PORT]")
@@ -138,21 +139,20 @@ class _Plugin(object):
         session = Network._Session(session_id, self._network)
         main_conn, process_conn = Pipe()
         session.plugin_pipe = main_conn
-        process = Process(target=_Plugin._launch_plugin, args=(self._plugin_class, session_id, process_conn, _Plugin.__serializer, _Plugin._plugin_id, version_table, _TypeSerializer.get_version_table()))
+        process = Process(target=_Plugin._launch_plugin, args=(self._plugin_class, session_id, process_conn, _Plugin.__serializer, _Plugin._plugin_id, version_table, _TypeSerializer.get_version_table(), Logs.is_verbose()))
         process.start()
         session.plugin_process = process
         self._sessions[session_id] = session
         Logs.debug("Registered new session:", session_id)
 
     @classmethod
-    def _launch_plugin_profile(cls, plugin_class, session_id, pipe, serializer, plugin_id, version_table, original_version_table):
-        cProfile.runctx('_Plugin._launch_plugin(plugin_class, session_id, pipe, serializer, plugin_id, version_table, original_version_table)', globals(), locals(), 'profile.out')
+    def _launch_plugin_profile(cls, plugin_class, session_id, pipe, serializer, plugin_id, version_table, original_version_table, verbose):
+        cProfile.runctx('_Plugin._launch_plugin(plugin_class, session_id, pipe, serializer, plugin_id, version_table, original_version_table, verbose)', globals(), locals(), 'profile.out')
 
     @classmethod
-    def _launch_plugin(cls, plugin_class, session_id, pipe, serializer, plugin_id, version_table, original_version_table):
-        Logs.debug("Creating process")
+    def _launch_plugin(cls, plugin_class, session_id, pipe, serializer, plugin_id, version_table, original_version_table, verbose):
         plugin = plugin_class()
-        _PluginInstance.__init__(plugin, session_id, pipe, serializer, plugin_id, version_table, original_version_table, Logs.is_verbose())
+        _PluginInstance.__init__(plugin, session_id, pipe, serializer, plugin_id, version_table, original_version_table, verbose)
         Logs.debug("Starting plugin")
         plugin._run()
 

--- a/nanome/_internal/_plugin.py
+++ b/nanome/_internal/_plugin.py
@@ -17,11 +17,12 @@ class _Plugin(object):
     def __parse_args(self):
         for i in range(1, len(sys.argv)):
             if sys.argv[i] == "-h":
-                Logs.debug("Usage:", sys.argv[1],"[-h] [-a ADDRESS] [-p PORT]")
-                Logs.debug(" -h  display this help")
-                Logs.debug(" -a  connects to a NTS at the specified IP address")
-                Logs.debug(" -p  connects to a NTS at the specified port")
-                Logs.debug(" -k  specifies a key file to use to connect to NTS")
+                Logs.message("Usage:", sys.argv[1],"[-h] [-a ADDRESS] [-p PORT]")
+                Logs.message(" -h  display this help")
+                Logs.message(" -a  connects to a NTS at the specified IP address")
+                Logs.message(" -p  connects to a NTS at the specified port")
+                Logs.message(" -k  specifies a key file to use to connect to NTS")
+                Logs.message(" -v  enable verbose mode, to display Logs.debug")
                 sys.exit(0)
             elif sys.argv[i] == "-a":
                 if i >= len(sys.argv):
@@ -45,6 +46,8 @@ class _Plugin(object):
                     sys.exit(1)
                 self.__key_file = sys.argv[i + 1]
                 i += 1
+            elif sys.argv[i] == "-v":
+                Logs.set_verbose(True)
 
     def __read_key_file(self):
         try:
@@ -74,7 +77,7 @@ class _Plugin(object):
 
         elif packet.packet_type == Network._Packet.packet_type_plugin_connection:
             _Plugin._plugin_id = packet.plugin_id
-            Logs.debug("Registered with plugin ID", _Plugin._plugin_id, "\n=======================================\n")
+            Logs.message("Registered with plugin ID", _Plugin._plugin_id, "\n=======================================\n")
 
         elif packet.packet_type == Network._Packet.packet_type_plugin_disconnection:
             if _Plugin._plugin_id == -1:
@@ -149,7 +152,7 @@ class _Plugin(object):
     def _launch_plugin(cls, plugin_class, session_id, pipe, serializer, plugin_id, version_table, original_version_table):
         Logs.debug("Creating process")
         plugin = plugin_class()
-        _PluginInstance.__init__(plugin, session_id, pipe, serializer, plugin_id, version_table, original_version_table)
+        _PluginInstance.__init__(plugin, session_id, pipe, serializer, plugin_id, version_table, original_version_table, Logs.is_verbose())
         Logs.debug("Starting plugin")
         plugin._run()
 

--- a/nanome/_internal/_plugin_instance.py
+++ b/nanome/_internal/_plugin_instance.py
@@ -37,7 +37,9 @@ class _PluginInstance(object):
             self._network._close()
             return
 
-    def __init__(self, session_id, pipe, serializer, plugin_id, version_table, original_version_table):
+    def __init__(self, session_id, pipe, serializer, plugin_id, version_table, original_version_table, verbose):
+        Logs.set_verbose(verbose)
+        
         self._network = _ProcessNetwork(self, session_id, pipe, serializer, plugin_id, version_table)
         Logs.debug("Plugin constructed for session", session_id)
         self._network._send(_Messages.connect, [_Packet._has_brotli_compression(), original_version_table])

--- a/nanome/util/logs.py
+++ b/nanome/util/logs.py
@@ -13,6 +13,15 @@ class Logs(object):
         'error': {'color': '\x1b[91m', 'msg': 'Error: '}
     }
     _closing = '\x1b[0m'
+    __verbose = False
+
+    @classmethod
+    def set_verbose(cls, value):
+        cls.__verbose = value
+
+    @classmethod
+    def is_verbose(cls):
+        return cls.__verbose
 
     @classmethod
     def _print(cls, col_type, *args):
@@ -27,8 +36,13 @@ class Logs(object):
         cls._print(cls._print_type['warning'], *args)
 
     @classmethod
-    def debug(cls, *args):
+    def message(cls, *args):
         cls._print(cls._print_type['debug'], *args)
+
+    @classmethod
+    def debug(cls, *args):
+        if cls.__verbose:
+            cls._print(cls._print_type['debug'], *args)
 
     @classmethod
     def init(cls):

--- a/nanome/util/logs.py
+++ b/nanome/util/logs.py
@@ -13,7 +13,7 @@ class Logs(object):
         'error': {'color': '\x1b[91m', 'msg': 'Error: '}
     }
     _closing = '\x1b[0m'
-    __verbose = False
+    __verbose = None
 
     @classmethod
     def set_verbose(cls, value):
@@ -41,7 +41,10 @@ class Logs(object):
 
     @classmethod
     def debug(cls, *args):
-        if cls.__verbose:
+        if cls.__verbose == None:
+            Logs.warning("Debug used before plugin start.")
+            cls._print(cls._print_type['debug'], *args)
+        elif cls.__verbose == True:
             cls._print(cls._print_type['debug'], *args)
 
     @classmethod


### PR DESCRIPTION
Logs.debug are now only displayed if plugin is called with -v
One caveat tho: if for some reason we try to Logs.debug before the command line is parsed (which is one of the first thing to happen)