### PR TITLE
Np 4281 optimize python serializers

### DIFF
--- a/nanome/_internal/_network/_commands/_serialization/_create_stream.py
+++ b/nanome/_internal/_network/_commands/_serialization/_create_stream.py
@@ -3,8 +3,7 @@ from nanome._internal._util._serializers import _TypeSerializer
 
 class _CreateStream(_TypeSerializer):
     def __init__(self):
-        self.__array = _ArraySerializer()
-        self.__array.set_type(_LongSerializer())
+        pass
 
     def version(self):
         return 0
@@ -13,7 +12,7 @@ class _CreateStream(_TypeSerializer):
         return "StreamCreation"
 
     def serialize(self, version, value, context):
-        context.write_using_serializer(self.__array, value)
+        context.write_long_array(value)
 
     def deserialize(self, version, context):
         raise NotImplementedError

--- a/nanome/_internal/_network/_commands/_serialization/_feed_stream.py
+++ b/nanome/_internal/_network/_commands/_serialization/_feed_stream.py
@@ -1,4 +1,3 @@
-from nanome._internal._util._serializers import _ArraySerializer, _FloatSerializer
 from nanome._internal._util._serializers import _TypeSerializer
 
 class _FeedStream(_TypeSerializer):

--- a/nanome/_internal/_network/_commands/_serialization/_feed_stream.py
+++ b/nanome/_internal/_network/_commands/_serialization/_feed_stream.py
@@ -3,8 +3,7 @@ from nanome._internal._util._serializers import _TypeSerializer
 
 class _FeedStream(_TypeSerializer):
     def __init__(self):
-        self.__array = _ArraySerializer()
-        self.__array.set_type(_FloatSerializer())
+        pass
 
     def version(self):
         return 0
@@ -14,7 +13,7 @@ class _FeedStream(_TypeSerializer):
 
     def serialize(self, version, value, context):
         context.write_uint(value[0])
-        context.write_using_serializer(self.__array, value[1])
+        context.write_float_array(value[1])
 
     def deserialize(self, version, context):
         raise NotImplementedError

--- a/nanome/_internal/_network/_commands/_serialization/_position_structures.py
+++ b/nanome/_internal/_network/_commands/_serialization/_position_structures.py
@@ -8,8 +8,7 @@ import types
 
 class _PositionStructures(_TypeSerializer):
     def __init__(self):
-        self.array_serializer = _ArraySerializer()
-        self.array_serializer.set_type(_LongSerializer())
+        pass
 
     def name(self):
         return "PositionStructures"
@@ -35,7 +34,7 @@ class _PositionStructures(_TypeSerializer):
                 for atom in val.atoms:
                     atom_ids.append(atom._index)
 
-        context.write_using_serializer(self.array_serializer, atom_ids)
+        context.write_long_array(atom_ids)
 
     def deserialize(self, version, context):
         return None

--- a/nanome/_internal/_network/_commands/_serialization/_request_complex_list.py
+++ b/nanome/_internal/_network/_commands/_serialization/_request_complex_list.py
@@ -22,8 +22,7 @@ from nanome._internal._util._serializers import _TypeSerializer
 
 class _RequestComplexes(_TypeSerializer):
     def __init__(self):
-        self._array = _ArraySerializer()
-        self._array.set_type(_LongSerializer())
+        pass
 
     def version(self):
         return 0
@@ -32,7 +31,7 @@ class _RequestComplexes(_TypeSerializer):
         return "RequestComplexes"
 
     def serialize(self, version, value, context):
-        context.write_using_serializer(self._array, value)
+        context.write_long_array(value)
 
     def deserialize(self, version, context):
         return None

--- a/nanome/_internal/_network/_data.py
+++ b/nanome/_internal/_network/_data.py
@@ -202,7 +202,6 @@ class _Data(object):
         if byte_size > self._buffered_bytes:
             raise BufferError(
                 'Trying to read more data than available, check API compatibility')
-        print(len(self._received_bytes[self._buffered_computed:self._buffered_computed + size]))
         result = struct.unpack(str(size) + "i", self._received_bytes[self._buffered_computed:self._buffered_computed + byte_size])
         self.consume_data(byte_size)
         return result

--- a/nanome/_internal/_network/_data.py
+++ b/nanome/_internal/_network/_data.py
@@ -190,6 +190,7 @@ class _Data(object):
                 'Trying to read more data than available, check API compatibility')
 
         result = struct.unpack(str(size) + "f", self._received_bytes[self._buffered_computed:self._buffered_computed + byte_size])
+        self.consume_data(byte_size)
         return result
 
     def read_int_array(self):
@@ -203,6 +204,7 @@ class _Data(object):
                 'Trying to read more data than available, check API compatibility')
         print(len(self._received_bytes[self._buffered_computed:self._buffered_computed + size]))
         result = struct.unpack(str(size) + "i", self._received_bytes[self._buffered_computed:self._buffered_computed + byte_size])
+        self.consume_data(byte_size)
         return result
 
     def read_long_array(self):
@@ -216,5 +218,6 @@ class _Data(object):
                 'Trying to read more data than available, check API compatibility')
     
         result = struct.unpack(str(size) + "q", self._received_bytes[self._buffered_computed:self._buffered_computed + byte_size])
+        self.consume_data(byte_size)
         return result
 #end region

--- a/nanome/_internal/_network/_data.py
+++ b/nanome/_internal/_network/_data.py
@@ -84,6 +84,31 @@ class _Data(object):
         size = len(data)
         self.expand_data(size)
         self._received_bytes[pre:pre+size] = data
+
+    def write_floats(self, data):
+        pre = self._buffered_bytes + self._buffered_computed
+        size = len(data)
+        byte_size = size * 4
+        pack_into = struct.Struct(str(size) + "f").pack_into
+        self.expand_data(byte_size)
+        pack_into(self._received_bytes, pre, *data)
+
+    def write_ints(self, data):
+        pre = self._buffered_bytes + self._buffered_computed
+        size = len(data)
+        byte_size = size * 4
+        pack_into = struct.Struct(str(size) + "i").pack_into
+        self.expand_data(byte_size)
+        pack_into(self._received_bytes, pre, *data)
+
+    def write_longs(self, data):
+        pre = self._buffered_bytes + self._buffered_computed
+        size = len(data)
+        byte_size = size * 8
+        pack_into = struct.Struct(str(size) + "q").pack_into
+        self.expand_data(byte_size)
+        pack_into(self._received_bytes, pre, *data)
+
 #endregion
 #region read Data
     def consume_data(self, size):

--- a/nanome/_internal/_network/_serialization/_context.py
+++ b/nanome/_internal/_network/_serialization/_context.py
@@ -89,6 +89,15 @@ class _ContextSerialization(object):
         self._data.write_uint(0xCAFEB006)
         self._data.write_uint(value)
 
+    def write_float_array(self, value):
+        self._data.write_float_array(value)
+
+    def write_int_array(self, value):
+        self._data.write_int_array(value)
+
+    def write_long_array(self, value):
+        self._data.write_long_array(value)
+
     def write_using_serializer(self, serializer, value):
         try:
             version = self.__version_table[serializer.name()]
@@ -197,6 +206,15 @@ class _ContextDeserialization(object):
         if debug_flag != 0xCAFEB006:
             self.__packet_debugging_exception._raise("uint")
         return self._data.read_uint()
+
+    def read_int_array(self):
+        return self._data.read_int_array()
+
+    def read_float_array(self):
+        return self._data.read_float_array()
+
+    def read_long_array(self):
+        return self._data.read_long_array()
 
     def read_using_serializer(self, serializer):
         try:

--- a/nanome/_internal/_structure/_serialization/_workspace_serializer.py
+++ b/nanome/_internal/_structure/_serialization/_workspace_serializer.py
@@ -27,8 +27,8 @@ class _WorkspaceSerializer(_TypeSerializer):
     def deserialize(self, version, context):
         workspace = _Workspace._create()
         workspace._complexes = context.read_using_serializer(self.array)
-        workspace.transform._position = context.read_using_serializer(self.vector)
-        workspace.transform._rotation = context.read_using_serializer(self.quaternion)
-        workspace.transform._scale = context.read_using_serializer(self.vector)
+        workspace._transform._position = context.read_using_serializer(self.vector)
+        workspace._transform._rotation = context.read_using_serializer(self.quaternion)
+        workspace._transform._scale = context.read_using_serializer(self.vector)
 
         return workspace

--- a/nanome/_internal/_ui/_serialization/_layout_node_serializer.py
+++ b/nanome/_internal/_ui/_serialization/_layout_node_serializer.py
@@ -5,8 +5,7 @@ from nanome._internal._util._serializers import _TypeSerializer
 
 class _LayoutNodeSerializer(_TypeSerializer):
     def __init__(self):
-        self.array = _ArraySerializer()
-        self.array.set_type(_IntSerializer())
+        pass
 
     def version(self):
         return 0
@@ -30,7 +29,7 @@ class _LayoutNodeSerializer(_TypeSerializer):
         child_ids = []
         for child in value._children:
             child_ids.append(child._id)
-        context.write_using_serializer(self.array, child_ids)
+        context.write_int_array(child_ids)
         has_content = value._content != None
         context.write_bool(has_content)
         if (has_content):
@@ -50,7 +49,7 @@ class _LayoutNodeSerializer(_TypeSerializer):
                                 context.read_float(), 
                                 context.read_float(), 
                                 context.read_float())
-        layout_node._child_ids = context.read_using_serializer(self.array)
+        layout_node._child_ids = context.read_int_array()
         has_content = context.read_bool()
         if (has_content):
             layout_node._content_id = context.read_int()

--- a/nanome/_internal/_util/_serializers/_float_serializer.py
+++ b/nanome/_internal/_util/_serializers/_float_serializer.py
@@ -15,4 +15,5 @@ class _FloatSerializer(_TypeSerializer):
 
     def deserialize(self, version, context):
         return context.read_float()
-
+#to supress warning for unused serializer.
+_FloatSerializer()

--- a/nanome/_internal/_volumetric/_serialization/_volume_data_serializer.py
+++ b/nanome/_internal/_volumetric/_serialization/_volume_data_serializer.py
@@ -1,5 +1,5 @@
 from .. import _VolumeData
-from nanome._internal._util._serializers import _TypeSerializer, _FloatSerializer, _ArraySerializer
+from nanome._internal._util._serializers import _TypeSerializer
 
 class _VolumeDataSerializer(_TypeSerializer):
     def __init__(self):

--- a/nanome/_internal/_volumetric/_serialization/_volume_data_serializer.py
+++ b/nanome/_internal/_volumetric/_serialization/_volume_data_serializer.py
@@ -3,8 +3,8 @@ from nanome._internal._util._serializers import _TypeSerializer, _FloatSerialize
 
 class _VolumeDataSerializer(_TypeSerializer):
     def __init__(self):
-        self.float_array = _ArraySerializer()
-        self.float_array.set_type(_FloatSerializer())
+        pass
+
     def version(self):
         return 0
 
@@ -25,7 +25,7 @@ class _VolumeDataSerializer(_TypeSerializer):
         context.write_float(value._origin_y)
         context.write_float(value._origin_z)
 
-        context.write_using_serializer(self.float_array, value._data)
+        context.write_float_array(value._data)
 
     def deserialize(self, version, context):
         result = _VolumeData(0,0,0,0,0,0)
@@ -42,6 +42,6 @@ class _VolumeDataSerializer(_TypeSerializer):
         result._origin_y = context.read_float()
         result._origin_z = context.read_float()
 
-        result._data = context.read_using_serializer(self.float_array)
+        result._data = context.read_float_array()
 
         return result

--- a/testing/context_tests.py
+++ b/testing/context_tests.py
@@ -1,0 +1,165 @@
+import nanome
+import os
+import sys
+import struct
+import random
+from testing import utilities as util
+
+from testing.utilities import *
+
+from nanome.util import Logs
+
+from nanome._internal._network import _Data
+
+def run(counter):
+    run_test(primitive_tests, counter)
+    run_test(array_tests, counter)
+
+def primitive_tests():
+    buffer = _Data()
+    test_values = []
+    #bool
+    test_values.append(True)
+    buffer.write_bool(test_values[-1])
+    test_values.append(False)
+    buffer.write_bool(test_values[-1])
+    #int
+    test_values.append(0x7FFFFFFF) #max signed int
+    buffer.write_int(test_values[-1])
+    test_values.append(-0x7FFFFFFF) #min signed int
+    buffer.write_int(test_values[-1])
+    #single float
+    test_values.append(float("inf")) #float infinity
+    buffer.write_float(test_values[-1])
+    test_values.append(float("-inf")) #float infinity
+    buffer.write_float(test_values[-1])
+    test_values.append(340282346638528859811704183484516925440) #max float
+    buffer.write_float(test_values[-1])
+    test_values.append(-340282346638528859811704183484516925440) #min float
+    buffer.write_float(test_values[-1])
+    #long
+    test_values.append(0x7FFFFFFFFFFFFFFF) #max long
+    buffer.write_long(test_values[-1])
+    test_values.append(-0x7FFFFFFFFFFFFFFF) #min long
+    buffer.write_long(test_values[-1])
+    #uint
+    test_values.append(0xFFFFFFFF) #max uint
+    buffer.write_uint(test_values[-1])
+    test_values.append(0x00000000) #min uint
+    buffer.write_uint(test_values[-1])
+    #(unsigned) byte
+    test_values.append(0xFF) #max byte
+    buffer.write_byte(test_values[-1])
+    test_values.append(0x00) #min byte
+    buffer.write_byte(test_values[-1])
+    #Randoms
+    test_values.append(rand_int())
+    buffer.write_int(test_values[-1])
+    test_values.append(rand_float())
+    buffer.write_float(test_values[-1])
+    test_values.append(rand_positive_long())
+    buffer.write_long(test_values[-1])
+    test_values.append(rand_negative_long())
+    buffer.write_long(test_values[-1])
+    test_values.append(rand_uint())
+    buffer.write_uint(test_values[-1])
+    test_values.append(rand_byte())
+    buffer.write_byte(test_values[-1])
+
+    #check vals
+    i=0
+    assert (buffer.read_bool() == test_values[i])
+    i += 1
+    assert (buffer.read_bool() == test_values[i])
+    i += 1
+    assert (buffer.read_int() == test_values[i])
+    i += 1
+    assert (buffer.read_int() == test_values[i])
+    i += 1
+    assert (buffer.read_float() == test_values[i])
+    i += 1
+    assert (buffer.read_float() == test_values[i])
+    i += 1
+    assert (buffer.read_float() == test_values[i])
+    i += 1
+    assert (buffer.read_float() == test_values[i])
+    i += 1
+    assert (buffer.read_long() == test_values[i])
+    i += 1
+    assert (buffer.read_long() == test_values[i])
+    i += 1
+    assert (buffer.read_uint() == test_values[i])
+    i += 1
+    assert (buffer.read_uint() == test_values[i])
+    i += 1
+    assert (buffer.read_byte() == test_values[i])
+    i += 1
+    assert (buffer.read_byte() == test_values[i])
+    i += 1
+    #randoms
+    assert (buffer.read_int() == test_values[i])
+    i += 1
+    assert (buffer.read_float() == test_values[i])
+    i += 1
+    assert (buffer.read_long() == test_values[i])
+    i += 1
+    assert (buffer.read_long() == test_values[i])
+    i += 1
+    assert (buffer.read_uint() == test_values[i])
+    i += 1
+    assert (buffer.read_byte() == test_values[i])
+    i += 1
+
+    #check the buffer is empty
+    empty = False
+    try:
+        buffer.read_byte()
+    except:
+        empty=True
+    assert(empty)
+
+def array_tests():
+    ints_in = []
+    for _ in range(1000):
+        ints_in.append(rand_int())
+
+    floats_in = []
+    for _ in range(1000):
+        floats_in.append(rand_float())
+
+    longs_in = []
+    for _ in range(1000):
+        longs_in.append(rand_positive_long())
+        longs_in.append(rand_negative_long())
+
+    buffer = _Data()
+    buffer.write_int_array(ints_in)
+    buffer.write_float_array(floats_in)
+    buffer.write_long_array(longs_in)
+
+    ints_out = buffer.read_int_array()
+    floats_out = buffer.read_float_array()
+    longs_out = buffer.read_long_array()
+    assert(tuple(ints_in) == ints_out)
+    assert(tuple(floats_in) == floats_out)
+    assert(tuple(longs_in) == longs_out)
+
+def rand_int():
+    return random.randint(-0x7FFFFFFF, 0x7FFFFFFF)
+
+def rand_float():
+    dbl = random.uniform(-340282346638528859811704183484516925440, 340282346638528859811704183484516925440)
+    flt = struct.unpack('f', struct.pack('f', dbl))[0]
+    return flt
+
+def rand_positive_long():
+    return random.randint(0x7FFFFFFF, 0x7FFFFFFFFFFFFFFF)
+
+def rand_negative_long():
+    return random.randint(-0x7FFFFFFFFFFFFFFF, -0x7FFFFFFF)
+
+def rand_uint():
+    return random.randint(0x00000000, 0xFFFFFFFF)
+
+def rand_byte():
+    return random.randint(0x00, 0xFF)

--- a/tests.py
+++ b/tests.py
@@ -4,6 +4,7 @@ from testing import sdf_tests
 from testing import ui_tests
 from testing import json_tests
 from testing import api_tests
+from testing import context_tests
 from testing import utilities as util
 
 import os
@@ -30,6 +31,7 @@ def get_download_path():
 import nanome
 
 all_tests_passed = True
+all_tests_passed = all_tests_passed and util.run_test_group(context_tests)
 all_tests_passed = all_tests_passed and util.run_test_group(api_tests)
 all_tests_passed = all_tests_passed and util.run_test_group(atom_tests)
 all_tests_passed = all_tests_passed and util.run_test_group(mmcif_tests)


### PR DESCRIPTION
primitive array serializers now directly write to buffer rather than repeatedly writing single primitives.

Added unit tests.