### PR TITLE
Fix Instance Crash on Linux

### DIFF
--- a/nanome/_internal/_network/_process_network.py
+++ b/nanome/_internal/_network/_process_network.py
@@ -26,6 +26,7 @@ class _ProcessNetwork(object):
         self._plugin._call(request_id, *args)
 
     def _close(self):
+        self._process_conn.send(stop_bytes)
         self._process_conn.close()
 
     @classmethod

--- a/nanome/_internal/_network/_session.py
+++ b/nanome/_internal/_network/_session.py
@@ -17,6 +17,9 @@ class _Session(object):
             return False
         if has_net_data:
             packet = self.__net_plugin_pipe.recv()
+            if packet == stop_bytes:
+                Logs.error("Plugin encountered an error")
+                return False
             self._net_plugin.send(packet)
         if has_proc_data:
             request = self.__proc_plugin_pipe.recv()
@@ -40,9 +43,12 @@ class _Session(object):
         packet.set(self._session_id, _Packet.packet_type_plugin_disconnection, plugin_id)
         self._net_plugin.send(packet)
 
-    def close_pipes(self):
+    def signal_and_close_pipes(self):
         self._on_packet_received(stop_bytes)
         self._closed = True
+        self.close_pipes()
+
+    def close_pipes(self):
         self.__net_plugin_pipe.close()
         self.__proc_plugin_pipe.close()
 

--- a/nanome/_internal/_plugin.py
+++ b/nanome/_internal/_plugin.py
@@ -169,6 +169,7 @@ class _Plugin(object):
                 to_remove.clear()
                 for id, session in self._sessions.items():
                     if session._read_from_plugin() == False:
+                        session.close_pipes()
                         to_remove.append(id)
                 for id in to_remove:
                     self._sessions[id]._send_disconnection_message(_Plugin._plugin_id)

--- a/nanome/_internal/_plugin_instance.py
+++ b/nanome/_internal/_plugin_instance.py
@@ -24,8 +24,11 @@ class _PluginInstance(object):
 
     def _call(self, id, *args):
         callbacks = _PluginInstance.__callbacks
-        callbacks[id](*args)
-        del callbacks[id]
+        try:
+            callbacks[id](*args)
+            del callbacks[id]
+        except KeyError:
+            Logs.warning('Received an unknown callback id:', id)
 
     def _run(self):
         try:
@@ -43,6 +46,7 @@ class _PluginInstance(object):
             return
         except:
             Logs.error(traceback.format_exc())
+            self._process_manager._close()
             self._network._close()
             return
 

--- a/nanome/_internal/_process/_process_manager_instance.py
+++ b/nanome/_internal/_process/_process_manager_instance.py
@@ -11,6 +11,9 @@ class _ProcessManagerInstance():
         self.__pending_start = deque()
         self.__processes = dict()
 
+    def _close(self):
+        self.__pipe.close()
+
     def update(self):
         has_data = None
         try:


### PR DESCRIPTION
Prevent crash for unknown callback id
Send disconnection message to Nanome if instance crashes on linux
Close all pipes on both sides when crashing