### PR TITLE
Custom Data

### DIFF
--- a/nanome/_internal/_plugin.py
+++ b/nanome/_internal/_plugin.py
@@ -20,6 +20,7 @@ __metaclass__ = type
 class _Plugin(object):
     __serializer = Serializer()
     _plugin_id = -1
+    _custom_data = None
 
     def __parse_args(self):
         Logs._set_verbose(False)
@@ -197,7 +198,7 @@ class _Plugin(object):
         main_conn_net, process_conn_net = Pipe()
         main_conn_proc, process_conn_proc = Pipe()
         session = Network._Session(session_id, self._network, self._process_manager, main_conn_net, main_conn_proc)
-        process = Process(target=_Plugin._launch_plugin, args=(self._plugin_class, session_id, process_conn_net, process_conn_proc, _Plugin.__serializer, _Plugin._plugin_id, version_table, _TypeSerializer.get_version_table(), Logs._is_verbose()))
+        process = Process(target=_Plugin._launch_plugin, args=(self._plugin_class, session_id, process_conn_net, process_conn_proc, _Plugin.__serializer, _Plugin._plugin_id, version_table, _TypeSerializer.get_version_table(), Logs._is_verbose(), _Plugin._custom_data))
         process.start()
         session.plugin_process = process
         self._sessions[session_id] = session
@@ -208,13 +209,13 @@ class _Plugin(object):
         return current_process().name != 'MainProcess'
 
     @classmethod
-    def _launch_plugin_profile(cls, plugin_class, session_id, pipe_net, pipe_proc, serializer, plugin_id, version_table, original_version_table, verbose):
-        cProfile.runctx('_Plugin._launch_plugin(plugin_class, session_id, pipe_net, pipe_proc, serializer, plugin_id, version_table, original_version_table, verbose)', globals(), locals(), 'profile.out')
+    def _launch_plugin_profile(cls, plugin_class, session_id, pipe_net, pipe_proc, serializer, plugin_id, version_table, original_version_table, verbose, custom_data):
+        cProfile.runctx('_Plugin._launch_plugin(plugin_class, session_id, pipe_net, pipe_proc, serializer, plugin_id, version_table, original_version_table, verbose, custom_data)', globals(), locals(), 'profile.out')
 
     @classmethod
-    def _launch_plugin(cls, plugin_class, session_id, pipe_net, pipe_proc, serializer, plugin_id, version_table, original_version_table, verbose):
+    def _launch_plugin(cls, plugin_class, session_id, pipe_net, pipe_proc, serializer, plugin_id, version_table, original_version_table, verbose, custom_data):
         plugin = plugin_class()
-        _PluginInstance.__init__(plugin, session_id, pipe_net, pipe_proc, serializer, plugin_id, version_table, original_version_table, verbose)
+        _PluginInstance.__init__(plugin, session_id, pipe_net, pipe_proc, serializer, plugin_id, version_table, original_version_table, verbose, custom_data)
         Logs.debug("Starting plugin")
         plugin._run()
 

--- a/nanome/_internal/_plugin_instance.py
+++ b/nanome/_internal/_plugin_instance.py
@@ -58,7 +58,7 @@ class _PluginInstance(object):
             self._network._close()
             return
 
-    def __init__(self, session_id, net_pipe, proc_pipe, serializer, plugin_id, version_table, original_version_table, verbose):
+    def __init__(self, session_id, net_pipe, proc_pipe, serializer, plugin_id, version_table, original_version_table, verbose, custom_data):
         Logs._set_verbose(verbose)
 
         self._network = _ProcessNetwork(self, session_id, net_pipe, serializer, plugin_id, version_table)
@@ -69,3 +69,4 @@ class _PluginInstance(object):
         self._run_usable = True
         self._advanced_settings_text = "Advanced Settings"
         self._advanced_settings_usable = True
+        self._custom_data = custom_data

--- a/nanome/api/plugin.py
+++ b/nanome/api/plugin.py
@@ -31,6 +31,16 @@ class Plugin(_Plugin):
             plugin.run(host, port, key_file)
 
     @staticmethod
+    def set_custom_data(*args):
+        """
+        | Store arbitrary data to send to plugin instances
+
+        :param args: Variable length argument list
+        :type args: Anything serializable
+        """
+        _Plugin._custom_data = args
+
+    @staticmethod
     def set_maximum_processes_count(max_process_nb):
         _ProcessManager._max_process_count = max_process_nb
 

--- a/nanome/api/plugin_instance.py
+++ b/nanome/api/plugin_instance.py
@@ -362,6 +362,15 @@ class PluginInstance(_PluginInstance):
         if not os.path.exists(path):
             os.makedirs(path)
         return path
+
+    @property
+    def custom_data(self):
+        """
+        Get custom data set with Plugin.set_custom_data
+
+        :type: tuple of objects or None if no data has been set
+        """
+        return self._custom_data
         
 class _DefaultPlugin(PluginInstance):
     def __init__(self):


### PR DESCRIPTION
Add a simple function to set custom data to pass to plugin instances.
For instance, a plugin can read arguments, then set custom values to pass to instances, and instance can access them with self.custom_data
Or the plugin can directly pass sys.argv to its instances