### PR TITLE
Fix bonding

### DIFF
--- a/nanome/_internal/_process/_bonding.py
+++ b/nanome/_internal/_process/_bonding.py
@@ -111,6 +111,8 @@ class _Bonding():
                 new_bond = self.__get_bond(atom1, atom2)
                 if new_bond is None:
                     new_bond = _Bond._create()
+                    new_bond._kind = bond._kind
+
                     if self.__saved_is_conformer:
                         conformer_count = atom1.conformer_count
                         new_bond._kinds = [new_bond._kind] * conformer_count

--- a/nanome/_internal/_process/_bonding.py
+++ b/nanome/_internal/_process/_bonding.py
@@ -79,36 +79,42 @@ class _Bonding():
         self.__match_and_bond(result)
         self.__next()
 
-    def __get_bond(self, atom1, atom2):
-        if atom1.serial > atom2.serial:
-            atom1, atom2 = atom2, atom1
-        for bond in atom1._bonds:
-            if bond._atom1 == atom1 and bond._atom2 == atom2:
-                return bond
-        return None
-
     def __match_and_bond(self, bonding_result):
         if self.__molecule_idx == 0:
             for atom in self.__saved_complex.atoms:
                 atom._bonds.clear()
             for residue in self.__saved_complex.residues:
                 residue._bonds.clear()
-        
+
         if self.__molecule_idx == 0 or not self.__saved_is_conformer:
             self.__atom_by_serial = dict()
             molecule = self.__saved_complex._molecules[self.__molecule_idx]
+
+            # obabel removes gaps in atom serials going from pdb to sdf
+            # we need to remove the gaps before matching output to saved complex
+            atom_serial = 1
             for atom in molecule.atoms:
-                self.__atom_by_serial[atom._serial] = atom
+                self.__atom_by_serial[atom_serial] = atom
+                atom_serial += 1
 
         for bond in bonding_result.bonds:
             serial1 = bond._atom1._serial
             serial2 = bond._atom2._serial
+
+            if serial1 > serial2:
+                serial1, serial2 = serial2, serial1
+
             if serial1 in self.__atom_by_serial and serial2 in self.__atom_by_serial:
                 atom1 = self.__atom_by_serial[serial1]
                 atom2 = self.__atom_by_serial[serial2]
                 residue = atom1._residue
 
-                new_bond = self.__get_bond(atom1, atom2)
+                new_bond = None
+                for old_bond in atom1.bonds:
+                    if old_bond._atom2 == atom2:
+                        new_bond = old_bond
+                        break
+
                 if new_bond is None:
                     new_bond = _Bond._create()
                     new_bond._kind = bond._kind
@@ -123,8 +129,7 @@ class _Bonding():
                     residue._add_bond(new_bond)
 
                 if self.__saved_is_conformer:
-                    current_conformer = self.__molecule_idx
-                    new_bond._in_conformer[current_conformer] = True
+                    new_bond._in_conformer[self.__molecule_idx] = True
 
     def __done(self):
         self.__input.close()

--- a/nanome/_internal/_structure/_io/_sdf/save.py
+++ b/nanome/_internal/_structure/_io/_sdf/save.py
@@ -46,7 +46,7 @@ def to_file(path, complex, options=None):
             return None
         for chain in chains:
             for residue in chain._residues:
-                for atom in residue.atoms:
+                for atom in residue._atoms:
                     serial_by_atom_serial[atom._serial] = atom_serial
                     saved_atom = Results.SavedAtom()
                     saved_atom.serial = atom_serial

--- a/test_plugins/BondingTest.py
+++ b/test_plugins/BondingTest.py
@@ -1,0 +1,30 @@
+import os
+import requests
+import tempfile
+
+import nanome
+
+class BondingTest(nanome.PluginInstance):
+    def start(self):
+        self.on_run()
+
+    def on_run(self):
+        # load_url = 'https://files.rcsb.org/download/1tyl.pdb'
+        # response = requests.get(load_url)
+        # temp = tempfile.NamedTemporaryFile(delete=False)
+        # temp.write(response.text.encode("utf-8"))
+        # temp.close()
+        # complex = nanome.structure.Complex.io.from_pdb(path=temp.name)
+        # os.remove(temp.name)
+
+        pdb_path = os.path.join(os.getcwd(), "testing/test_assets/pdb/1tyl.pdb")
+        complex = nanome.structure.Complex.io.from_pdb(path=pdb_path)
+
+        def bonding_done(complex_list):
+            self.add_to_workspace(complex_list)
+            print('done')
+
+        self.add_bonds([complex], bonding_done)
+        print('starting bonding')
+
+nanome.Plugin.setup('Bonding Test', 'Tests add_bonds', 'testing', False, BondingTest)

--- a/testing/test_assets/pdb/1tyl.pdb
+++ b/testing/test_assets/pdb/1tyl.pdb
@@ -1,0 +1,1570 @@
+HEADER    HORMONE                                 21-JUN-94   1TYL              
+TITLE     THE STRUCTURE OF A COMPLEX OF HEXAMERIC INSULIN AND 4'-               
+TITLE    2 HYDROXYACETANILIDE                                                   
+COMPND    MOL_ID: 1;                                                            
+COMPND   2 MOLECULE: INSULIN;                                                   
+COMPND   3 CHAIN: A, C;                                                         
+COMPND   4 ENGINEERED: YES;                                                     
+COMPND   5 MOL_ID: 2;                                                           
+COMPND   6 MOLECULE: INSULIN;                                                   
+COMPND   7 CHAIN: B, D;                                                         
+COMPND   8 ENGINEERED: YES                                                      
+SOURCE    MOL_ID: 1;                                                            
+SOURCE   2 ORGANISM_SCIENTIFIC: HOMO SAPIENS;                                   
+SOURCE   3 ORGANISM_COMMON: HUMAN;                                              
+SOURCE   4 ORGANISM_TAXID: 9606;                                                
+SOURCE   5 MOL_ID: 2;                                                           
+SOURCE   6 ORGANISM_SCIENTIFIC: HOMO SAPIENS;                                   
+SOURCE   7 ORGANISM_COMMON: HUMAN;                                              
+SOURCE   8 ORGANISM_TAXID: 9606                                                 
+KEYWDS    HORMONE                                                               
+EXPDTA    X-RAY DIFFRACTION                                                     
+AUTHOR    G.D.SMITH,E.CISZAK                                                    
+REVDAT   3   24-FEB-09 1TYL    1       VERSN                                    
+REVDAT   2   15-JAN-95 1TYL    1       JRNL                                     
+REVDAT   1   30-SEP-94 1TYL    0                                                
+JRNL        AUTH   G.D.SMITH,E.CISZAK                                           
+JRNL        TITL   THE STRUCTURE OF A COMPLEX OF HEXAMERIC INSULIN              
+JRNL        TITL 2 AND 4'-HYDROXYACETANILIDE.                                   
+JRNL        REF    PROC.NATL.ACAD.SCI.USA        V.  91  8851 1994              
+JRNL        REFN                   ISSN 0027-8424                               
+JRNL        PMID   8090735                                                      
+JRNL        DOI    10.1073/PNAS.91.19.8851                                      
+REMARK   1                                                                      
+REMARK   1 REFERENCE 1                                                          
+REMARK   1  AUTH   E.CISZAK,G.D.SMITH                                           
+REMARK   1  TITL   CRYSTALLOGRAPHIC EVIDENCE FOR DUAL COORDINATION              
+REMARK   1  TITL 2 AROUND ZINC IN THE T3R3 HUMAN INSULIN HEXAMER                
+REMARK   1  REF    BIOCHEMISTRY                  V.  33  1512 1994              
+REMARK   1  REFN                   ISSN 0006-2960                               
+REMARK   1 REFERENCE 2                                                          
+REMARK   1  AUTH   G.D.SMITH,D.C.SWENSON,E.J.DODSON,G.G.DODSON,                 
+REMARK   1  AUTH 2 C.D.REYNOLDS                                                 
+REMARK   1  TITL   STRUCTURAL STABILITY IN THE 4-ZINC HUMAN INSULIN             
+REMARK   1  TITL 2 HEXAMER                                                      
+REMARK   1  REF    PROC.NATL.ACAD.SCI.USA        V.  81  7093 1984              
+REMARK   1  REFN                   ISSN 0027-8424                               
+REMARK   2                                                                      
+REMARK   2 RESOLUTION.    1.90 ANGSTROMS.                                       
+REMARK   3                                                                      
+REMARK   3 REFINEMENT.                                                          
+REMARK   3   PROGRAM     : PROFFT                                               
+REMARK   3   AUTHORS     : KONNERT,HENDRICKSON,FINZEL                           
+REMARK   3                                                                      
+REMARK   3  DATA USED IN REFINEMENT.                                            
+REMARK   3   RESOLUTION RANGE HIGH (ANGSTROMS) : 1.90                           
+REMARK   3   RESOLUTION RANGE LOW  (ANGSTROMS) : NULL                           
+REMARK   3   DATA CUTOFF            (SIGMA(F)) : NULL                           
+REMARK   3   COMPLETENESS FOR RANGE        (%) : NULL                           
+REMARK   3   NUMBER OF REFLECTIONS             : NULL                           
+REMARK   3                                                                      
+REMARK   3  FIT TO DATA USED IN REFINEMENT.                                     
+REMARK   3   CROSS-VALIDATION METHOD          : NULL                            
+REMARK   3   FREE R VALUE TEST SET SELECTION  : NULL                            
+REMARK   3   R VALUE     (WORKING + TEST SET) : 0.168                           
+REMARK   3   R VALUE            (WORKING SET) : NULL                            
+REMARK   3   FREE R VALUE                     : NULL                            
+REMARK   3   FREE R VALUE TEST SET SIZE   (%) : NULL                            
+REMARK   3   FREE R VALUE TEST SET COUNT      : NULL                            
+REMARK   3                                                                      
+REMARK   3  FIT/AGREEMENT OF MODEL WITH ALL DATA.                               
+REMARK   3   R VALUE   (WORKING + TEST SET, NO CUTOFF) : NULL                   
+REMARK   3   R VALUE          (WORKING SET, NO CUTOFF) : NULL                   
+REMARK   3   FREE R VALUE                  (NO CUTOFF) : NULL                   
+REMARK   3   FREE R VALUE TEST SET SIZE (%, NO CUTOFF) : NULL                   
+REMARK   3   FREE R VALUE TEST SET COUNT   (NO CUTOFF) : NULL                   
+REMARK   3   TOTAL NUMBER OF REFLECTIONS   (NO CUTOFF) : NULL                   
+REMARK   3                                                                      
+REMARK   3  NUMBER OF NON-HYDROGEN ATOMS USED IN REFINEMENT.                    
+REMARK   3   PROTEIN ATOMS            : 791                                     
+REMARK   3   NUCLEIC ACID ATOMS       : 0                                       
+REMARK   3   HETEROGEN ATOMS          : 14                                      
+REMARK   3   SOLVENT ATOMS            : 110                                     
+REMARK   3                                                                      
+REMARK   3  B VALUES.                                                           
+REMARK   3   FROM WILSON PLOT           (A**2) : NULL                           
+REMARK   3   MEAN B VALUE      (OVERALL, A**2) : NULL                           
+REMARK   3   OVERALL ANISOTROPIC B VALUE.                                       
+REMARK   3    B11 (A**2) : NULL                                                 
+REMARK   3    B22 (A**2) : NULL                                                 
+REMARK   3    B33 (A**2) : NULL                                                 
+REMARK   3    B12 (A**2) : NULL                                                 
+REMARK   3    B13 (A**2) : NULL                                                 
+REMARK   3    B23 (A**2) : NULL                                                 
+REMARK   3                                                                      
+REMARK   3  ESTIMATED COORDINATE ERROR.                                         
+REMARK   3   ESD FROM LUZZATI PLOT        (A) : NULL                            
+REMARK   3   ESD FROM SIGMAA              (A) : NULL                            
+REMARK   3   LOW RESOLUTION CUTOFF        (A) : NULL                            
+REMARK   3                                                                      
+REMARK   3  RMS DEVIATIONS FROM IDEAL VALUES.                                   
+REMARK   3   DISTANCE RESTRAINTS.                    RMS    SIGMA               
+REMARK   3    BOND LENGTH                     (A) : 0.019 ; NULL                
+REMARK   3    ANGLE DISTANCE                  (A) : NULL  ; NULL                
+REMARK   3    INTRAPLANAR 1-4 DISTANCE        (A) : NULL  ; NULL                
+REMARK   3    H-BOND OR METAL COORDINATION    (A) : NULL  ; NULL                
+REMARK   3                                                                      
+REMARK   3   PLANE RESTRAINT                  (A) : NULL  ; NULL                
+REMARK   3   CHIRAL-CENTER RESTRAINT       (A**3) : NULL  ; NULL                
+REMARK   3                                                                      
+REMARK   3   NON-BONDED CONTACT RESTRAINTS.                                     
+REMARK   3    SINGLE TORSION                  (A) : NULL  ; NULL                
+REMARK   3    MULTIPLE TORSION                (A) : NULL  ; NULL                
+REMARK   3    H-BOND (X...Y)                  (A) : NULL  ; NULL                
+REMARK   3    H-BOND (X-H...Y)                (A) : NULL  ; NULL                
+REMARK   3                                                                      
+REMARK   3   CONFORMATIONAL TORSION ANGLE RESTRAINTS.                           
+REMARK   3    SPECIFIED                 (DEGREES) : NULL  ; NULL                
+REMARK   3    PLANAR                    (DEGREES) : NULL  ; NULL                
+REMARK   3    STAGGERED                 (DEGREES) : NULL  ; NULL                
+REMARK   3    TRANSVERSE                (DEGREES) : NULL  ; NULL                
+REMARK   3                                                                      
+REMARK   3  ISOTROPIC THERMAL FACTOR RESTRAINTS.    RMS    SIGMA                
+REMARK   3   MAIN-CHAIN BOND               (A**2) : NULL  ; NULL                
+REMARK   3   MAIN-CHAIN ANGLE              (A**2) : NULL  ; NULL                
+REMARK   3   SIDE-CHAIN BOND               (A**2) : NULL  ; NULL                
+REMARK   3   SIDE-CHAIN ANGLE              (A**2) : NULL  ; NULL                
+REMARK   3                                                                      
+REMARK   3  OTHER REFINEMENT REMARKS: NULL                                      
+REMARK   4                                                                      
+REMARK   4 1TYL COMPLIES WITH FORMAT V. 3.15, 01-DEC-08                         
+REMARK 100                                                                      
+REMARK 100 THIS ENTRY HAS BEEN PROCESSED BY BNL.                                
+REMARK 200                                                                      
+REMARK 200 EXPERIMENTAL DETAILS                                                 
+REMARK 200  EXPERIMENT TYPE                : X-RAY DIFFRACTION                  
+REMARK 200  DATE OF DATA COLLECTION        : NULL                               
+REMARK 200  TEMPERATURE           (KELVIN) : NULL                               
+REMARK 200  PH                             : NULL                               
+REMARK 200  NUMBER OF CRYSTALS USED        : NULL                               
+REMARK 200                                                                      
+REMARK 200  SYNCHROTRON              (Y/N) : NULL                               
+REMARK 200  RADIATION SOURCE               : NULL                               
+REMARK 200  BEAMLINE                       : NULL                               
+REMARK 200  X-RAY GENERATOR MODEL          : NULL                               
+REMARK 200  MONOCHROMATIC OR LAUE    (M/L) : NULL                               
+REMARK 200  WAVELENGTH OR RANGE        (A) : NULL                               
+REMARK 200  MONOCHROMATOR                  : NULL                               
+REMARK 200  OPTICS                         : NULL                               
+REMARK 200                                                                      
+REMARK 200  DETECTOR TYPE                  : NULL                               
+REMARK 200  DETECTOR MANUFACTURER          : NULL                               
+REMARK 200  INTENSITY-INTEGRATION SOFTWARE : NULL                               
+REMARK 200  DATA SCALING SOFTWARE          : NULL                               
+REMARK 200                                                                      
+REMARK 200  NUMBER OF UNIQUE REFLECTIONS   : NULL                               
+REMARK 200  RESOLUTION RANGE HIGH      (A) : NULL                               
+REMARK 200  RESOLUTION RANGE LOW       (A) : NULL                               
+REMARK 200  REJECTION CRITERIA  (SIGMA(I)) : NULL                               
+REMARK 200                                                                      
+REMARK 200 OVERALL.                                                             
+REMARK 200  COMPLETENESS FOR RANGE     (%) : NULL                               
+REMARK 200  DATA REDUNDANCY                : NULL                               
+REMARK 200  R MERGE                    (I) : NULL                               
+REMARK 200  R SYM                      (I) : NULL                               
+REMARK 200  <I/SIGMA(I)> FOR THE DATA SET  : NULL                               
+REMARK 200                                                                      
+REMARK 200 IN THE HIGHEST RESOLUTION SHELL.                                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE HIGH (A) : NULL                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE LOW  (A) : NULL                     
+REMARK 200  COMPLETENESS FOR SHELL     (%) : NULL                               
+REMARK 200  DATA REDUNDANCY IN SHELL       : NULL                               
+REMARK 200  R MERGE FOR SHELL          (I) : NULL                               
+REMARK 200  R SYM FOR SHELL            (I) : NULL                               
+REMARK 200  <I/SIGMA(I)> FOR SHELL         : NULL                               
+REMARK 200                                                                      
+REMARK 200 DIFFRACTION PROTOCOL: NULL                                           
+REMARK 200 METHOD USED TO DETERMINE THE STRUCTURE: NULL                         
+REMARK 200 SOFTWARE USED: NULL                                                  
+REMARK 200 STARTING MODEL: NULL                                                 
+REMARK 200                                                                      
+REMARK 200 REMARK: NULL                                                         
+REMARK 280                                                                      
+REMARK 280 CRYSTAL                                                              
+REMARK 280 SOLVENT CONTENT, VS   (%): 40.45                                     
+REMARK 280 MATTHEWS COEFFICIENT, VM (ANGSTROMS**3/DA): 2.07                     
+REMARK 280                                                                      
+REMARK 280 CRYSTALLIZATION CONDITIONS: NULL                                     
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY                                            
+REMARK 290 SYMMETRY OPERATORS FOR SPACE GROUP: H 3                              
+REMARK 290                                                                      
+REMARK 290      SYMOP   SYMMETRY                                                
+REMARK 290     NNNMMM   OPERATOR                                                
+REMARK 290       1555   X,Y,Z                                                   
+REMARK 290       2555   -Y,X-Y,Z                                                
+REMARK 290       3555   -X+Y,-X,Z                                               
+REMARK 290       4555   X+2/3,Y+1/3,Z+1/3                                       
+REMARK 290       5555   -Y+2/3,X-Y+1/3,Z+1/3                                    
+REMARK 290       6555   -X+Y+2/3,-X+1/3,Z+1/3                                   
+REMARK 290       7555   X+1/3,Y+2/3,Z+2/3                                       
+REMARK 290       8555   -Y+1/3,X-Y+2/3,Z+2/3                                    
+REMARK 290       9555   -X+Y+1/3,-X+2/3,Z+2/3                                   
+REMARK 290                                                                      
+REMARK 290     WHERE NNN -> OPERATOR NUMBER                                     
+REMARK 290           MMM -> TRANSLATION VECTOR                                  
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY TRANSFORMATIONS                            
+REMARK 290 THE FOLLOWING TRANSFORMATIONS OPERATE ON THE ATOM/HETATM             
+REMARK 290 RECORDS IN THIS ENTRY TO PRODUCE CRYSTALLOGRAPHICALLY                
+REMARK 290 RELATED MOLECULES.                                                   
+REMARK 290   SMTRY1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   2 -0.500000 -0.866025  0.000000        0.00000            
+REMARK 290   SMTRY2   2  0.866025 -0.500000  0.000000        0.00000            
+REMARK 290   SMTRY3   2  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   3 -0.500000  0.866025  0.000000        0.00000            
+REMARK 290   SMTRY2   3 -0.866025 -0.500000  0.000000        0.00000            
+REMARK 290   SMTRY3   3  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   4  1.000000  0.000000  0.000000       40.55500            
+REMARK 290   SMTRY2   4  0.000000  1.000000  0.000000       23.41444            
+REMARK 290   SMTRY3   4  0.000000  0.000000  1.000000       12.65667            
+REMARK 290   SMTRY1   5 -0.500000 -0.866025  0.000000       40.55500            
+REMARK 290   SMTRY2   5  0.866025 -0.500000  0.000000       23.41444            
+REMARK 290   SMTRY3   5  0.000000  0.000000  1.000000       12.65667            
+REMARK 290   SMTRY1   6 -0.500000  0.866025  0.000000       40.55500            
+REMARK 290   SMTRY2   6 -0.866025 -0.500000  0.000000       23.41444            
+REMARK 290   SMTRY3   6  0.000000  0.000000  1.000000       12.65667            
+REMARK 290   SMTRY1   7  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   7  0.000000  1.000000  0.000000       46.82888            
+REMARK 290   SMTRY3   7  0.000000  0.000000  1.000000       25.31333            
+REMARK 290   SMTRY1   8 -0.500000 -0.866025  0.000000        0.00000            
+REMARK 290   SMTRY2   8  0.866025 -0.500000  0.000000       46.82888            
+REMARK 290   SMTRY3   8  0.000000  0.000000  1.000000       25.31333            
+REMARK 290   SMTRY1   9 -0.500000  0.866025  0.000000        0.00000            
+REMARK 290   SMTRY2   9 -0.866025 -0.500000  0.000000       46.82888            
+REMARK 290   SMTRY3   9  0.000000  0.000000  1.000000       25.31333            
+REMARK 290                                                                      
+REMARK 290 REMARK: NULL                                                         
+REMARK 300                                                                      
+REMARK 300 BIOMOLECULE: 1, 2, 3, 4, 5, 6, 7, 8                                  
+REMARK 300 SEE REMARK 350 FOR THE AUTHOR PROVIDED AND/OR PROGRAM                
+REMARK 300 GENERATED ASSEMBLY INFORMATION FOR THE STRUCTURE IN                  
+REMARK 300 THIS ENTRY. THE REMARK MAY ALSO PROVIDE INFORMATION ON               
+REMARK 300 BURIED SURFACE AREA.                                                 
+REMARK 300 REMARK:                                                              
+REMARK 300 THE CRYSTALLOGRAPHIC ASYMMETRIC UNIT OF INSULIN CONSISTS             
+REMARK 300 OF TWO INSULIN MONOMERS EACH CONSISTING OF TWO                       
+REMARK 300 HETEROCHAINS.  THE ENTRY PRESENTS COORDINATES FOR MONOMER            
+REMARK 300 I (CHAIN IDENTIFIERS A AND B) AND II (CHAIN IDENTIFIERS C            
+REMARK 300 AND D).  APPLYING THE THREE-FOLD CRYSTALLOGRAPHIC SYMMETRY           
+REMARK 300 AXIS YIELDS A HEXAMER AROUND THE AXIS.  THERE ARE TWO ZINC           
+REMARK 300 IONS PER INSULIN HEXAMER LOCATED ON THE THREE-FOLD AXIS.             
+REMARK 300 WATERS HOH 1, HOH 104, AND HOH 105 ARE LOCATED ON THE                
+REMARK 300 THREE-FOLD AXIS.                                                     
+REMARK 350                                                                      
+REMARK 350 COORDINATES FOR A COMPLETE MULTIMER REPRESENTING THE KNOWN           
+REMARK 350 BIOLOGICALLY SIGNIFICANT OLIGOMERIZATION STATE OF THE                
+REMARK 350 MOLECULE CAN BE GENERATED BY APPLYING BIOMT TRANSFORMATIONS          
+REMARK 350 GIVEN BELOW.  BOTH NON-CRYSTALLOGRAPHIC AND                          
+REMARK 350 CRYSTALLOGRAPHIC OPERATIONS ARE GIVEN.                               
+REMARK 350                                                                      
+REMARK 350 BIOMOLECULE: 1                                                       
+REMARK 350 AUTHOR DETERMINED BIOLOGICAL UNIT: DIMERIC                           
+REMARK 350 SOFTWARE DETERMINED QUATERNARY STRUCTURE: DIMERIC                    
+REMARK 350 SOFTWARE USED: PISA                                                  
+REMARK 350 TOTAL BURIED SURFACE AREA: 1720 ANGSTROM**2                          
+REMARK 350 SURFACE AREA OF THE COMPLEX: 3630 ANGSTROM**2                        
+REMARK 350 CHANGE IN SOLVENT FREE ENERGY: -15.0 KCAL/MOL                        
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: A, B                                  
+REMARK 350   BIOMT1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 350                                                                      
+REMARK 350 BIOMOLECULE: 2                                                       
+REMARK 350 AUTHOR DETERMINED BIOLOGICAL UNIT: DIMERIC                           
+REMARK 350 SOFTWARE DETERMINED QUATERNARY STRUCTURE: DIMERIC                    
+REMARK 350 SOFTWARE USED: PISA                                                  
+REMARK 350 TOTAL BURIED SURFACE AREA: 1120 ANGSTROM**2                          
+REMARK 350 SURFACE AREA OF THE COMPLEX: 3720 ANGSTROM**2                        
+REMARK 350 CHANGE IN SOLVENT FREE ENERGY: -11.0 KCAL/MOL                        
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: C, D                                  
+REMARK 350   BIOMT1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 350                                                                      
+REMARK 350 BIOMOLECULE: 3                                                       
+REMARK 350 SOFTWARE DETERMINED QUATERNARY STRUCTURE: DODECAMERIC                
+REMARK 350 SOFTWARE USED: PISA                                                  
+REMARK 350 TOTAL BURIED SURFACE AREA: 18930 ANGSTROM**2                         
+REMARK 350 SURFACE AREA OF THE COMPLEX: 11960 ANGSTROM**2                       
+REMARK 350 CHANGE IN SOLVENT FREE ENERGY: -281.0 KCAL/MOL                       
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: A, B, C, D                            
+REMARK 350   BIOMT1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 350   BIOMT1   2 -0.500000 -0.866025  0.000000        0.00000            
+REMARK 350   BIOMT2   2  0.866025 -0.500000  0.000000        0.00000            
+REMARK 350   BIOMT3   2  0.000000  0.000000  1.000000        0.00000            
+REMARK 350   BIOMT1   3 -0.500000  0.866025  0.000000        0.00000            
+REMARK 350   BIOMT2   3 -0.866025 -0.500000  0.000000        0.00000            
+REMARK 350   BIOMT3   3  0.000000  0.000000  1.000000        0.00000            
+REMARK 350                                                                      
+REMARK 350 BIOMOLECULE: 4                                                       
+REMARK 350 SOFTWARE DETERMINED QUATERNARY STRUCTURE: TETRAMERIC                 
+REMARK 350 SOFTWARE USED: PISA                                                  
+REMARK 350 TOTAL BURIED SURFACE AREA: 4020 ANGSTROM**2                          
+REMARK 350 SURFACE AREA OF THE COMPLEX: 6170 ANGSTROM**2                        
+REMARK 350 CHANGE IN SOLVENT FREE ENERGY: -32.0 KCAL/MOL                        
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: C, D                                  
+REMARK 350   BIOMT1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: A, B                                  
+REMARK 350   BIOMT1   2 -0.500000 -0.866025  0.000000        0.00000            
+REMARK 350   BIOMT2   2  0.866025 -0.500000  0.000000        0.00000            
+REMARK 350   BIOMT3   2  0.000000  0.000000  1.000000        0.00000            
+REMARK 350                                                                      
+REMARK 350 BIOMOLECULE: 5                                                       
+REMARK 350 SOFTWARE DETERMINED QUATERNARY STRUCTURE: TETRAMERIC                 
+REMARK 350 SOFTWARE USED: PISA                                                  
+REMARK 350 TOTAL BURIED SURFACE AREA: 4390 ANGSTROM**2                          
+REMARK 350 SURFACE AREA OF THE COMPLEX: 5800 ANGSTROM**2                        
+REMARK 350 CHANGE IN SOLVENT FREE ENERGY: -35.0 KCAL/MOL                        
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: A, B, C, D                            
+REMARK 350   BIOMT1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 350                                                                      
+REMARK 350 BIOMOLECULE: 6                                                       
+REMARK 350 SOFTWARE DETERMINED QUATERNARY STRUCTURE: NONAMERIC                  
+REMARK 350 SOFTWARE USED: PISA                                                  
+REMARK 350 TOTAL BURIED SURFACE AREA: 7160 ANGSTROM**2                          
+REMARK 350 SURFACE AREA OF THE COMPLEX: 15010 ANGSTROM**2                       
+REMARK 350 CHANGE IN SOLVENT FREE ENERGY: -102.0 KCAL/MOL                       
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: A, B, C                               
+REMARK 350   BIOMT1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 350   BIOMT1   2 -0.500000 -0.866025  0.000000        0.00000            
+REMARK 350   BIOMT2   2  0.866025 -0.500000  0.000000        0.00000            
+REMARK 350   BIOMT3   2  0.000000  0.000000  1.000000        0.00000            
+REMARK 350   BIOMT1   3 -0.500000  0.866025  0.000000        0.00000            
+REMARK 350   BIOMT2   3 -0.866025 -0.500000  0.000000        0.00000            
+REMARK 350   BIOMT3   3  0.000000  0.000000  1.000000        0.00000            
+REMARK 350                                                                      
+REMARK 350 BIOMOLECULE: 7                                                       
+REMARK 350 SOFTWARE DETERMINED QUATERNARY STRUCTURE: HEXAMERIC                  
+REMARK 350 SOFTWARE USED: PISA                                                  
+REMARK 350 TOTAL BURIED SURFACE AREA: 5010 ANGSTROM**2                          
+REMARK 350 SURFACE AREA OF THE COMPLEX: 9710 ANGSTROM**2                        
+REMARK 350 CHANGE IN SOLVENT FREE ENERGY: -139.0 KCAL/MOL                       
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: C, D                                  
+REMARK 350   BIOMT1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 350   BIOMT1   2 -0.500000 -0.866025  0.000000        0.00000            
+REMARK 350   BIOMT2   2  0.866025 -0.500000  0.000000        0.00000            
+REMARK 350   BIOMT3   2  0.000000  0.000000  1.000000        0.00000            
+REMARK 350   BIOMT1   3 -0.500000  0.866025  0.000000        0.00000            
+REMARK 350   BIOMT2   3 -0.866025 -0.500000  0.000000        0.00000            
+REMARK 350   BIOMT3   3  0.000000  0.000000  1.000000        0.00000            
+REMARK 350                                                                      
+REMARK 350 BIOMOLECULE: 8                                                       
+REMARK 350 SOFTWARE DETERMINED QUATERNARY STRUCTURE: HEXAMERIC                  
+REMARK 350 SOFTWARE USED: PISA                                                  
+REMARK 350 TOTAL BURIED SURFACE AREA: 5750 ANGSTROM**2                          
+REMARK 350 SURFACE AREA OF THE COMPLEX: 10420 ANGSTROM**2                       
+REMARK 350 CHANGE IN SOLVENT FREE ENERGY: -94.0 KCAL/MOL                        
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: A, B                                  
+REMARK 350   BIOMT1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 350   BIOMT1   2 -0.500000 -0.866025  0.000000        0.00000            
+REMARK 350   BIOMT2   2  0.866025 -0.500000  0.000000        0.00000            
+REMARK 350   BIOMT3   2  0.000000  0.000000  1.000000        0.00000            
+REMARK 350   BIOMT1   3 -0.500000  0.866025  0.000000        0.00000            
+REMARK 350   BIOMT2   3 -0.866025 -0.500000  0.000000        0.00000            
+REMARK 350   BIOMT3   3  0.000000  0.000000  1.000000        0.00000            
+REMARK 375                                                                      
+REMARK 375 SPECIAL POSITION                                                     
+REMARK 375 THE FOLLOWING ATOMS ARE FOUND TO BE WITHIN 0.15 ANGSTROMS            
+REMARK 375 OF A SYMMETRY RELATED ATOM AND ARE ASSUMED TO BE ON SPECIAL          
+REMARK 375 POSITIONS.                                                           
+REMARK 375                                                                      
+REMARK 375 ATOM RES CSSEQI                                                      
+REMARK 375 ZN    ZN B  31  LIES ON A SPECIAL POSITION.                          
+REMARK 375 ZN    ZN D  31  LIES ON A SPECIAL POSITION.                          
+REMARK 375 CL    CL D  32  LIES ON A SPECIAL POSITION.                          
+REMARK 375      HOH B  32  LIES ON A SPECIAL POSITION.                          
+REMARK 375      HOH D  52  LIES ON A SPECIAL POSITION.                          
+REMARK 375      HOH D  53  LIES ON A SPECIAL POSITION.                          
+REMARK 400                                                                      
+REMARK 400 COMPOUND                                                             
+REMARK 400                                                                      
+REMARK 400 THE CONFORMATIONS OF THE TWO MONOMERS ARE DIFFERENT AS THE           
+REMARK 400 RESULT OF A DIFFERENCE IN CONFORMATION AT THE N-TERMINI              
+REMARK 400 OF THE B AND D CHAINS.  IN MONOMER I, B 1 - B 8 ADOPT                
+REMARK 400 AN EXTENDED CONFORMATION (T STATE) WHILE IN MONOMER II               
+REMARK 400 RESIDUES D 4 THROUGH D 8 ARE ALPHA-HELICAL (R STATE).                
+REMARK 465                                                                      
+REMARK 465 MISSING RESIDUES                                                     
+REMARK 465 THE FOLLOWING RESIDUES WERE NOT LOCATED IN THE                       
+REMARK 465 EXPERIMENT. (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN               
+REMARK 465 IDENTIFIER; SSSEQ=SEQUENCE NUMBER; I=INSERTION CODE.)                
+REMARK 465                                                                      
+REMARK 465   M RES C SSSEQI                                                     
+REMARK 465     PHE D     1                                                      
+REMARK 465     VAL D     2                                                      
+REMARK 470                                                                      
+REMARK 470 MISSING ATOM                                                         
+REMARK 470 THE FOLLOWING RESIDUES HAVE MISSING ATOMS(M=MODEL NUMBER;            
+REMARK 470 RES=RESIDUE NAME; C=CHAIN IDENTIFIER; SSEQ=SEQUENCE NUMBER;          
+REMARK 470 I=INSERTION CODE):                                                   
+REMARK 470   M RES CSSEQI  ATOMS                                                
+REMARK 470     THR B  30    OG1  CG2                                            
+REMARK 470     LYS D  29    CG   CD   CE   NZ                                   
+REMARK 470     THR D  30    CA   C    O    CB   OG1  CG2                        
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: CLOSE CONTACTS IN SAME ASYMMETRIC UNIT                     
+REMARK 500                                                                      
+REMARK 500 THE FOLLOWING ATOMS ARE IN CLOSE CONTACT.                            
+REMARK 500                                                                      
+REMARK 500  ATM1  RES C  SSEQI   ATM2  RES C  SSEQI           DISTANCE          
+REMARK 500   OE1  GLU B    21     O    HOH B    63              2.06            
+REMARK 500   OE1  GLN A     5     O    HOH A    24              2.07            
+REMARK 500   O    HOH D    35     O    HOH D    40              2.09            
+REMARK 500   O    HOH A    22     O    HOH A    34              2.19            
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: COVALENT BOND ANGLES                                       
+REMARK 500                                                                      
+REMARK 500 THE STEREOCHEMICAL PARAMETERS OF THE FOLLOWING RESIDUES              
+REMARK 500 HAVE VALUES WHICH DEVIATE FROM EXPECTED VALUES BY MORE               
+REMARK 500 THAN 6*RMSD (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN               
+REMARK 500 IDENTIFIER; SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                 
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT: (10X,I3,1X,A3,1X,A1,I4,A1,3(1X,A4,2X),12X,F5.1)              
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES PROTEIN: ENGH AND HUBER, 1999                        
+REMARK 500 EXPECTED VALUES NUCLEIC ACID: CLOWNEY ET AL 1996                     
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI ATM1   ATM2   ATM3                                     
+REMARK 500    CYS A   6   CA  -  CB  -  SG  ANGL. DEV. =   6.8 DEGREES          
+REMARK 500    TYR A  14   CA  -  CB  -  CG  ANGL. DEV. = -12.5 DEGREES          
+REMARK 500    TYR A  14   CB  -  CG  -  CD2 ANGL. DEV. =   4.3 DEGREES          
+REMARK 500    TYR A  14   CB  -  CG  -  CD1 ANGL. DEV. =  -5.6 DEGREES          
+REMARK 500    GLU B  13   CG  -  CD  -  OE1 ANGL. DEV. =  13.3 DEGREES          
+REMARK 500    GLN C   5   CB  -  CG  -  CD  ANGL. DEV. =  19.3 DEGREES          
+REMARK 500    CYS C   7   CB  -  CA  -  C   ANGL. DEV. =   8.0 DEGREES          
+REMARK 500    GLU D  21   CB  -  CG  -  CD  ANGL. DEV. =  20.0 DEGREES          
+REMARK 500    GLU D  21   OE1 -  CD  -  OE2 ANGL. DEV. =  -7.4 DEGREES          
+REMARK 500    GLU D  21   CG  -  CD  -  OE1 ANGL. DEV. =  14.3 DEGREES          
+REMARK 500    ARG D  22   CD  -  NE  -  CZ  ANGL. DEV. =  10.3 DEGREES          
+REMARK 500    TYR D  26   CB  -  CG  -  CD1 ANGL. DEV. =  -4.2 DEGREES          
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: TORSION ANGLES                                             
+REMARK 500                                                                      
+REMARK 500 TORSION ANGLES OUTSIDE THE EXPECTED RAMACHANDRAN REGIONS:            
+REMARK 500 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
+REMARK 500 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                             
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT:(10X,I3,1X,A3,1X,A1,I4,A1,4X,F7.2,3X,F7.2)                    
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES: GJ KLEYWEGT AND TA JONES (1996). PHI/PSI-           
+REMARK 500 CHOLOGY: RAMACHANDRAN REVISITED. STRUCTURE 4, 1395 - 1400            
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI        PSI       PHI                                   
+REMARK 500    CYS A   7      -63.77    -99.13                                   
+REMARK 500    SER A   9     -166.59   -129.92                                   
+REMARK 500    LYS D  29      -89.51   -118.59                                   
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 525                                                                      
+REMARK 525 SOLVENT                                                              
+REMARK 525                                                                      
+REMARK 525 THE SOLVENT MOLECULES HAVE CHAIN IDENTIFIERS THAT                    
+REMARK 525 INDICATE THE POLYMER CHAIN WITH WHICH THEY ARE MOST                  
+REMARK 525 CLOSELY ASSOCIATED. THE REMARK LISTS ALL THE SOLVENT                 
+REMARK 525 MOLECULES WHICH ARE MORE THAN 5A AWAY FROM THE                       
+REMARK 525 NEAREST POLYMER CHAIN (M = MODEL NUMBER;                             
+REMARK 525 RES=RESIDUE NAME; C=CHAIN IDENTIFIER; SSEQ=SEQUENCE                  
+REMARK 525 NUMBER; I=INSERTION CODE):                                           
+REMARK 525                                                                      
+REMARK 525  M RES CSSEQI                                                        
+REMARK 525    HOH C 118        DISTANCE =  5.94 ANGSTROMS                       
+REMARK 525    HOH D  52        DISTANCE =  5.09 ANGSTROMS                       
+REMARK 525    HOH D  53        DISTANCE =  7.48 ANGSTROMS                       
+REMARK 525    HOH A  43        DISTANCE =  5.82 ANGSTROMS                       
+REMARK 525    HOH D  54        DISTANCE =  5.26 ANGSTROMS                       
+REMARK 525    HOH A  44        DISTANCE =  5.53 ANGSTROMS                       
+REMARK 525    HOH A  46        DISTANCE =  8.06 ANGSTROMS                       
+REMARK 525    HOH D  57        DISTANCE =  5.25 ANGSTROMS                       
+REMARK 525    HOH B  68        DISTANCE =  7.98 ANGSTROMS                       
+REMARK 600                                                                      
+REMARK 600 HETEROGEN                                                            
+REMARK 600                                                                      
+REMARK 600 EACH OF TWO ZINC IONS IS COORDINATED BY THE THREE SYMMETRY           
+REMARK 600 RELATED HIS B 10 SIDE CHAINS.  THE COORDINATION SPHERE OF            
+REMARK 600 ZN B 1 IS OCTAHEDRAL WITH THE REMAINING THREE SITES FILLED           
+REMARK 600 BY WATER, HOH 16.  THE COORDINATION OF ZN D 1 IS                     
+REMARK 600 TETRAHEDRAL TO CL D 2.                                               
+REMARK 620                                                                      
+REMARK 620 METAL COORDINATION                                                   
+REMARK 620  (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;              
+REMARK 620  SSEQ=SEQUENCE NUMBER; I=INSERTION CODE):                            
+REMARK 620                                                                      
+REMARK 620 COORDINATION ANGLES FOR:  M RES CSSEQI METAL                         
+REMARK 620                              ZN B  31  ZN                            
+REMARK 620 N RES CSSEQI ATOM                                                    
+REMARK 620 1 HOH B  35   O                                                      
+REMARK 620 2 HIS B  10   NE2 100.5                                              
+REMARK 620 3 HIS B  10   NE2  96.4  98.8                                        
+REMARK 620 4 HOH B  35   O    59.1 153.3 100.5                                  
+REMARK 620 5 HOH B  35   O    59.1  96.4 153.3  59.1                            
+REMARK 620 6 HIS B  10   NE2 153.3  98.8  98.8  96.4 100.5                      
+REMARK 620 N                    1     2     3     4     5                       
+REMARK 620                                                                      
+REMARK 620 COORDINATION ANGLES FOR:  M RES CSSEQI METAL                         
+REMARK 620                              ZN D  31  ZN                            
+REMARK 620 N RES CSSEQI ATOM                                                    
+REMARK 620 1  CL D  32  CL                                                      
+REMARK 620 2 HIS D  10   NE2 113.6                                              
+REMARK 620 3 HIS D  10   NE2 113.6 105.1                                        
+REMARK 620 4 HIS D  10   NE2 113.6 105.1 105.1                                  
+REMARK 620 5  CL D  32  CL     0.0 113.6 113.6 113.6                            
+REMARK 620 6  CL D  32  CL     0.0 113.6 113.6 113.6   0.0                      
+REMARK 620 N                    1     2     3     4     5                       
+REMARK 800                                                                      
+REMARK 800 SITE                                                                 
+REMARK 800 SITE_IDENTIFIER: TYL                                                 
+REMARK 800 EVIDENCE_CODE: AUTHOR                                                
+REMARK 800 SITE_DESCRIPTION: TYLENOL BINDING SITE, THE TYLENOL MOLECULE IS      
+REMARK 800  BOUND IN AN ELLIPTICAL CAVITY BETWEEN R STATE MONOMERS              
+REMARK 800 SITE_IDENTIFIER: AC1                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE ZN B 31                   
+REMARK 800 SITE_IDENTIFIER: AC2                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE ZN D 31                   
+REMARK 800 SITE_IDENTIFIER: AC3                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE CL D 32                   
+REMARK 800 SITE_IDENTIFIER: AC4                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE TYL C 100                 
+DBREF  1TYL A    1    21  UNP    P01308   INS_HUMAN       90    110             
+DBREF  1TYL B    1    30  UNP    P01308   INS_HUMAN       25     54             
+DBREF  1TYL C    1    21  UNP    P01308   INS_HUMAN       90    110             
+DBREF  1TYL D    1    30  UNP    P01308   INS_HUMAN       25     54             
+SEQRES   1 A   21  GLY ILE VAL GLU GLN CYS CYS THR SER ILE CYS SER LEU          
+SEQRES   2 A   21  TYR GLN LEU GLU ASN TYR CYS ASN                              
+SEQRES   1 B   30  PHE VAL ASN GLN HIS LEU CYS GLY SER HIS LEU VAL GLU          
+SEQRES   2 B   30  ALA LEU TYR LEU VAL CYS GLY GLU ARG GLY PHE PHE TYR          
+SEQRES   3 B   30  THR PRO LYS THR                                              
+SEQRES   1 C   21  GLY ILE VAL GLU GLN CYS CYS THR SER ILE CYS SER LEU          
+SEQRES   2 C   21  TYR GLN LEU GLU ASN TYR CYS ASN                              
+SEQRES   1 D   30  PHE VAL ASN GLN HIS LEU CYS GLY SER HIS LEU VAL GLU          
+SEQRES   2 D   30  ALA LEU TYR LEU VAL CYS GLY GLU ARG GLY PHE PHE TYR          
+SEQRES   3 D   30  THR PRO LYS THR                                              
+HET     ZN  B  31       1                                                       
+HET     ZN  D  31       1                                                       
+HET     CL  D  32       1                                                       
+HET    TYL  C 100      11                                                       
+HETNAM      ZN ZINC ION                                                         
+HETNAM      CL CHLORIDE ION                                                     
+HETNAM     TYL N-(4-HYDROXYPHENYL)ACETAMIDE (TYLENOL)                           
+FORMUL   5   ZN    2(ZN 2+)                                                     
+FORMUL   7   CL    CL 1-                                                        
+FORMUL   8  TYL    C8 H9 N O2                                                   
+FORMUL   9  HOH   *110(H2 O)                                                    
+HELIX    1  H1 GLY A    1  SER A    9  1                                   9    
+HELIX    2  H2 SER A   12  CYS A   20  5MIXED ALPHA, 3/10 HELIX            9    
+HELIX    3  H3 GLY B    8  GLY B   20  1T CONFORMATION                    13    
+HELIX    4  H4 GLY C    1  SER C    9  1                                   9    
+HELIX    5  H5 SER C   12  CYS C   20  5MIXED ALPHA, 3/10 HELIX            9    
+HELIX    6  H6 GLN D    4  GLY D   20  1R CONFORMATION                    17    
+SHEET    1  S1 2 PHE B  24  TYR B  26  0                                        
+SHEET    2  S1 2 PHE D  24  TYR D  26 -1  N  PHE D  24   O  TYR B  26           
+SSBOND   1 CYS A    6    CYS A   11                          1555   1555  2.02  
+SSBOND   2 CYS A    7    CYS B    7                          1555   1555  2.02  
+SSBOND   3 CYS A   20    CYS B   19                          1555   1555  2.07  
+SSBOND   4 CYS C    6    CYS C   11                          1555   1555  2.01  
+SSBOND   5 CYS C    7    CYS D    7                          1555   1555  2.04  
+SSBOND   6 CYS C   20    CYS D   19                          1555   1555  2.07  
+LINK        ZN    ZN B  31                 O   HOH B  35     1555   1555  2.45  
+LINK        ZN    ZN B  31                 NE2 HIS B  10     1555   1555  2.24  
+LINK        ZN    ZN D  31                CL    CL D  32     1555   1555  2.39  
+LINK        ZN    ZN D  31                 NE2 HIS D  10     1555   1555  2.06  
+LINK        ZN    ZN B  31                 NE2 HIS B  10     1555   2555  2.24  
+LINK        ZN    ZN B  31                 O   HOH B  35     1555   2555  2.45  
+LINK        ZN    ZN B  31                 O   HOH B  35     1555   3555  2.45  
+LINK        ZN    ZN B  31                 NE2 HIS B  10     1555   3555  2.24  
+LINK        ZN    ZN D  31                 NE2 HIS D  10     1555   2555  2.06  
+LINK        ZN    ZN D  31                 NE2 HIS D  10     1555   3555  2.06  
+LINK        ZN    ZN D  31                CL    CL D  32     1555   2555  2.39  
+LINK        ZN    ZN D  31                CL    CL D  32     1555   3555  2.39  
+SITE     1 TYL  8 GLU B  13  LEU B  17  CYS C   6  ILE C  10                    
+SITE     2 TYL  8 CYS C  11  HIS D   5  HIS D  10  LEU D  11                    
+SITE     1 AC1  2 HIS B  10  HOH B  35                                          
+SITE     1 AC2  2 HIS D  10   CL D  32                                          
+SITE     1 AC3  1  ZN D  31                                                     
+SITE     1 AC4 10 GLU B  13  LEU B  17  CYS C   6  SER C   9                    
+SITE     2 AC4 10 ILE C  10  CYS C  11  HIS D   5  HIS D  10                    
+SITE     3 AC4 10 LEU D  11  ALA D  14                                          
+CRYST1   81.110   81.110   37.970  90.00  90.00 120.00 H 3          18          
+ORIGX1      1.000000  0.000000  0.000000        0.00000                         
+ORIGX2      0.000000  1.000000  0.000000        0.00000                         
+ORIGX3      0.000000  0.000000  1.000000        0.00000                         
+SCALE1      0.012329  0.007118  0.000000        0.00000                         
+SCALE2      0.000000  0.014236  0.000000        0.00000                         
+SCALE3      0.000000  0.000000  0.026337        0.00000                         
+ATOM      1  N   GLY A   1      -0.781  20.645 -13.454  1.00 40.42           N  
+ATOM      2  CA  GLY A   1      -0.994  20.257 -12.017  1.00 41.87           C  
+ATOM      3  C   GLY A   1      -0.112  19.004 -11.799  1.00 40.44           C  
+ATOM      4  O   GLY A   1       0.578  18.621 -12.759  1.00 41.25           O  
+ATOM      5  N   ILE A   2      -0.164  18.465 -10.616  1.00 42.13           N  
+ATOM      6  CA  ILE A   2       0.621  17.290 -10.206  1.00 42.02           C  
+ATOM      7  C   ILE A   2       0.513  16.050 -11.074  1.00 43.43           C  
+ATOM      8  O   ILE A   2       1.582  15.443 -11.338  1.00 42.30           O  
+ATOM      9  CB  ILE A   2       0.393  17.004  -8.664  1.00 42.26           C  
+ATOM     10  CG1 ILE A   2       1.639  16.240  -8.156  1.00 41.55           C  
+ATOM     11  CG2 ILE A   2      -0.947  16.253  -8.397  1.00 40.27           C  
+ATOM     12  CD1 ILE A   2       1.735  15.968  -6.660  1.00 42.04           C  
+ATOM     13  N   VAL A   3      -0.658  15.628 -11.552  1.00 43.44           N  
+ATOM     14  CA  VAL A   3      -0.779  14.427 -12.386  1.00 43.40           C  
+ATOM     15  C   VAL A   3       0.061  14.487 -13.674  1.00 44.25           C  
+ATOM     16  O   VAL A   3       0.873  13.610 -14.037  1.00 42.88           O  
+ATOM     17  CB  VAL A   3      -2.278  14.108 -12.683  1.00 42.93           C  
+ATOM     18  CG1 VAL A   3      -2.368  12.980 -13.702  1.00 43.41           C  
+ATOM     19  CG2 VAL A   3      -3.054  13.809 -11.424  1.00 42.24           C  
+ATOM     20  N   GLU A   4      -0.150  15.586 -14.402  1.00 45.12           N  
+ATOM     21  CA  GLU A   4       0.539  15.841 -15.658  1.00 48.11           C  
+ATOM     22  C   GLU A   4       2.046  15.716 -15.478  1.00 47.86           C  
+ATOM     23  O   GLU A   4       2.636  14.928 -16.238  1.00 48.71           O  
+ATOM     24  CB  GLU A   4       0.215  17.184 -16.326  1.00 49.28           C  
+ATOM     25  CG  GLU A   4      -0.680  18.113 -15.515  1.00 52.93           C  
+ATOM     26  CD  GLU A   4      -2.031  17.628 -15.086  1.00 54.41           C  
+ATOM     27  OE1 GLU A   4      -2.829  17.055 -15.844  1.00 56.36           O  
+ATOM     28  OE2 GLU A   4      -2.278  17.874 -13.868  1.00 55.34           O  
+ATOM     29  N   GLN A   5       2.557  16.431 -14.521  1.00 48.48           N  
+ATOM     30  CA  GLN A   5       3.922  16.594 -14.079  1.00 48.14           C  
+ATOM     31  C   GLN A   5       4.582  15.342 -13.468  1.00 47.75           C  
+ATOM     32  O   GLN A   5       5.707  15.018 -13.897  1.00 45.92           O  
+ATOM     33  CB  GLN A   5       4.153  17.731 -13.075  1.00 49.40           C  
+ATOM     34  CG  GLN A   5       4.504  19.143 -13.485  1.00 50.44           C  
+ATOM     35  CD  GLN A   5       5.289  19.989 -12.528  1.00 51.40           C  
+ATOM     36  OE1 GLN A   5       5.162  20.139 -11.309  1.00 51.61           O  
+ATOM     37  NE2 GLN A   5       6.278  20.713 -13.069  1.00 51.75           N  
+ATOM     38  N   CYS A   6       3.893  14.736 -12.500  1.00 46.56           N  
+ATOM     39  CA  CYS A   6       4.491  13.562 -11.830  1.00 45.56           C  
+ATOM     40  C   CYS A   6       3.987  12.187 -12.234  1.00 44.86           C  
+ATOM     41  O   CYS A   6       4.710  11.189 -12.006  1.00 42.02           O  
+ATOM     42  CB  CYS A   6       4.478  13.782 -10.334  1.00 45.94           C  
+ATOM     43  SG  CYS A   6       5.156  15.267  -9.619  1.00 47.68           S  
+ATOM     44  N   CYS A   7       2.808  12.129 -12.821  1.00 43.70           N  
+ATOM     45  CA  CYS A   7       2.239  10.858 -13.246  1.00 44.54           C  
+ATOM     46  C   CYS A   7       2.513  10.730 -14.743  1.00 44.85           C  
+ATOM     47  O   CYS A   7       3.229   9.814 -15.136  1.00 44.48           O  
+ATOM     48  CB  CYS A   7       0.764  10.688 -12.963  1.00 43.10           C  
+ATOM     49  SG  CYS A   7      -0.077   9.259 -13.667  1.00 42.66           S  
+ATOM     50  N   THR A   8       1.923  11.640 -15.472  1.00 46.02           N  
+ATOM     51  CA  THR A   8       2.048  11.692 -16.943  1.00 47.32           C  
+ATOM     52  C   THR A   8       3.506  11.691 -17.373  1.00 47.10           C  
+ATOM     53  O   THR A   8       3.820  10.968 -18.346  1.00 49.07           O  
+ATOM     54  CB  THR A   8       1.086  12.820 -17.488  1.00 46.03           C  
+ATOM     55  OG1 THR A   8      -0.196  12.109 -17.446  1.00 46.86           O  
+ATOM     56  CG2 THR A   8       1.378  13.347 -18.868  1.00 47.45           C  
+ATOM     57  N   SER A   9       4.384  12.375 -16.692  1.00 47.59           N  
+ATOM     58  CA  SER A   9       5.820  12.380 -16.966  1.00 47.89           C  
+ATOM     59  C   SER A   9       6.520  12.107 -15.636  1.00 47.07           C  
+ATOM     60  O   SER A   9       5.835  11.639 -14.684  1.00 48.22           O  
+ATOM     61  CB  SER A   9       6.357  13.555 -17.743  1.00 48.94           C  
+ATOM     62  OG  SER A   9       6.013  14.793 -17.181  1.00 50.54           O  
+ATOM     63  N   ILE A  10       7.811  12.321 -15.551  1.00 46.54           N  
+ATOM     64  CA  ILE A  10       8.549  12.057 -14.303  1.00 44.52           C  
+ATOM     65  C   ILE A  10       9.041  13.241 -13.519  1.00 45.20           C  
+ATOM     66  O   ILE A  10       9.691  14.159 -14.068  1.00 47.42           O  
+ATOM     67  CB  ILE A  10       9.699  10.998 -14.553  1.00 43.39           C  
+ATOM     68  CG1 ILE A  10       8.972   9.722 -14.967  1.00 42.46           C  
+ATOM     69  CG2 ILE A  10      10.603  10.900 -13.287  1.00 41.18           C  
+ATOM     70  CD1 ILE A  10       9.523   8.840 -16.088  1.00 42.55           C  
+ATOM     71  N   CYS A  11       8.827  13.160 -12.218  1.00 44.56           N  
+ATOM     72  CA  CYS A  11       9.174  14.115 -11.204  1.00 45.50           C  
+ATOM     73  C   CYS A  11      10.362  13.892 -10.305  1.00 44.48           C  
+ATOM     74  O   CYS A  11      10.379  12.933  -9.522  1.00 46.68           O  
+ATOM     75  CB  CYS A  11       8.000  14.234 -10.135  1.00 46.74           C  
+ATOM     76  SG  CYS A  11       6.925  15.633 -10.520  1.00 49.04           S  
+ATOM     77  N   SER A  12      11.269  14.863 -10.259  1.00 43.84           N  
+ATOM     78  CA  SER A  12      12.428  14.762  -9.332  1.00 43.47           C  
+ATOM     79  C   SER A  12      11.886  15.026  -7.946  1.00 42.45           C  
+ATOM     80  O   SER A  12      10.775  15.567  -7.962  1.00 43.88           O  
+ATOM     81  CB  SER A  12      13.468  15.819  -9.693  1.00 44.37           C  
+ATOM     82  OG  SER A  12      12.930  17.123  -9.485  1.00 42.10           O  
+ATOM     83  N   LEU A  13      12.540  14.767  -6.854  1.00 41.84           N  
+ATOM     84  CA  LEU A  13      12.186  14.978  -5.495  1.00 41.37           C  
+ATOM     85  C   LEU A  13      11.776  16.425  -5.188  1.00 42.64           C  
+ATOM     86  O   LEU A  13      10.955  16.732  -4.317  1.00 43.43           O  
+ATOM     87  CB  LEU A  13      13.436  14.554  -4.649  1.00 39.10           C  
+ATOM     88  CG  LEU A  13      13.295  14.981  -3.209  1.00 40.11           C  
+ATOM     89  CD1 LEU A  13      12.053  14.377  -2.555  1.00 41.51           C  
+ATOM     90  CD2 LEU A  13      14.449  14.535  -2.321  1.00 41.03           C  
+ATOM     91  N   TYR A  14      12.422  17.321  -5.910  1.00 43.85           N  
+ATOM     92  CA  TYR A  14      12.265  18.762  -5.861  1.00 45.50           C  
+ATOM     93  C   TYR A  14      10.932  19.240  -6.437  1.00 44.14           C  
+ATOM     94  O   TYR A  14      10.348  20.170  -5.840  1.00 45.06           O  
+ATOM     95  CB  TYR A  14      13.511  19.457  -6.553  1.00 48.36           C  
+ATOM     96  CG  TYR A  14      14.644  19.010  -5.626  1.00 51.16           C  
+ATOM     97  CD1 TYR A  14      14.460  19.306  -4.263  1.00 52.58           C  
+ATOM     98  CD2 TYR A  14      15.723  18.229  -6.001  1.00 52.78           C  
+ATOM     99  CE1 TYR A  14      15.375  18.903  -3.286  1.00 54.28           C  
+ATOM    100  CE2 TYR A  14      16.644  17.800  -5.026  1.00 54.06           C  
+ATOM    101  CZ  TYR A  14      16.482  18.145  -3.694  1.00 54.63           C  
+ATOM    102  OH  TYR A  14      17.393  17.755  -2.739  1.00 56.52           O  
+ATOM    103  N   GLN A  15      10.563  18.627  -7.523  1.00 42.39           N  
+ATOM    104  CA  GLN A  15       9.323  18.875  -8.242  1.00 41.06           C  
+ATOM    105  C   GLN A  15       8.180  18.360  -7.355  1.00 39.74           C  
+ATOM    106  O   GLN A  15       7.140  19.018  -7.394  1.00 36.94           O  
+ATOM    107  CB  GLN A  15       9.263  18.405  -9.644  1.00 42.31           C  
+ATOM    108  CG  GLN A  15       9.979  19.266 -10.672  1.00 43.88           C  
+ATOM    109  CD  GLN A  15      10.247  18.378 -11.861  1.00 45.64           C  
+ATOM    110  OE1 GLN A  15       9.912  18.612 -13.024  1.00 48.93           O  
+ATOM    111  NE2 GLN A  15      10.879  17.260 -11.558  1.00 46.99           N  
+ATOM    112  N   LEU A  16       8.365  17.312  -6.587  1.00 37.55           N  
+ATOM    113  CA  LEU A  16       7.376  16.816  -5.636  1.00 36.80           C  
+ATOM    114  C   LEU A  16       7.138  17.713  -4.428  1.00 36.83           C  
+ATOM    115  O   LEU A  16       5.999  17.836  -3.867  1.00 34.64           O  
+ATOM    116  CB  LEU A  16       7.911  15.462  -5.108  1.00 37.96           C  
+ATOM    117  CG  LEU A  16       6.934  14.315  -4.973  1.00 40.97           C  
+ATOM    118  CD1 LEU A  16       6.165  14.141  -6.280  1.00 40.10           C  
+ATOM    119  CD2 LEU A  16       7.712  12.989  -4.706  1.00 40.22           C  
+ATOM    120  N   GLU A  17       8.213  18.368  -3.923  1.00 35.12           N  
+ATOM    121  CA  GLU A  17       8.116  19.240  -2.750  1.00 35.32           C  
+ATOM    122  C   GLU A  17       7.328  20.519  -3.041  1.00 31.35           C  
+ATOM    123  O   GLU A  17       6.950  21.176  -2.090  1.00 29.95           O  
+ATOM    124  CB  GLU A  17       9.412  19.607  -2.054  1.00 38.92           C  
+ATOM    125  CG  GLU A  17      10.282  18.349  -1.842  1.00 42.33           C  
+ATOM    126  CD  GLU A  17      11.410  18.642  -0.901  1.00 45.75           C  
+ATOM    127  OE1 GLU A  17      11.216  18.855   0.298  1.00 46.83           O  
+ATOM    128  OE2 GLU A  17      12.499  18.708  -1.522  1.00 46.86           O  
+ATOM    129  N   ASN A  18       7.100  20.838  -4.248  1.00 30.92           N  
+ATOM    130  CA  ASN A  18       6.292  22.011  -4.706  1.00 31.89           C  
+ATOM    131  C   ASN A  18       4.814  21.859  -4.245  1.00 32.42           C  
+ATOM    132  O   ASN A  18       3.992  22.788  -4.128  1.00 33.60           O  
+ATOM    133  CB  ASN A  18       6.386  21.944  -6.235  1.00 34.03           C  
+ATOM    134  CG  ASN A  18       7.620  22.593  -6.876  1.00 34.46           C  
+ATOM    135  OD1 ASN A  18       7.787  22.287  -8.081  1.00 37.12           O  
+ATOM    136  ND2 ASN A  18       8.258  23.389  -6.059  1.00 34.53           N  
+ATOM    137  N   TYR A  19       4.402  20.626  -3.979  1.00 31.90           N  
+ATOM    138  CA  TYR A  19       3.062  20.198  -3.536  1.00 32.60           C  
+ATOM    139  C   TYR A  19       2.943  20.054  -2.055  1.00 33.02           C  
+ATOM    140  O   TYR A  19       1.879  19.738  -1.446  1.00 34.02           O  
+ATOM    141  CB  TYR A  19       2.564  19.024  -4.400  1.00 31.13           C  
+ATOM    142  CG  TYR A  19       2.604  19.370  -5.855  1.00 32.02           C  
+ATOM    143  CD1 TYR A  19       1.643  20.243  -6.419  1.00 32.64           C  
+ATOM    144  CD2 TYR A  19       3.528  18.784  -6.709  1.00 31.95           C  
+ATOM    145  CE1 TYR A  19       1.705  20.557  -7.787  1.00 32.27           C  
+ATOM    146  CE2 TYR A  19       3.569  19.087  -8.045  1.00 33.47           C  
+ATOM    147  CZ  TYR A  19       2.639  20.002  -8.586  1.00 33.25           C  
+ATOM    148  OH  TYR A  19       2.787  20.213  -9.912  1.00 34.61           O  
+ATOM    149  N   CYS A  20       4.018  20.368  -1.308  1.00 32.73           N  
+ATOM    150  CA  CYS A  20       3.885  20.291   0.129  1.00 32.49           C  
+ATOM    151  C   CYS A  20       3.253  21.644   0.515  1.00 35.60           C  
+ATOM    152  O   CYS A  20       3.287  22.557  -0.312  1.00 37.34           O  
+ATOM    153  CB  CYS A  20       5.152  20.057   0.893  1.00 32.82           C  
+ATOM    154  SG  CYS A  20       6.167  18.690   0.289  1.00 33.32           S  
+ATOM    155  N   ASN A  21       2.820  21.680   1.728  1.00 39.12           N  
+ATOM    156  CA  ASN A  21       2.209  22.878   2.352  1.00 43.28           C  
+ATOM    157  C   ASN A  21       3.465  23.607   2.942  1.00 45.86           C  
+ATOM    158  O   ASN A  21       4.483  23.466   2.247  1.00 47.16           O  
+ATOM    159  CB  ASN A  21       1.198  22.655   3.438  1.00 42.10           C  
+ATOM    160  CG  ASN A  21      -0.090  21.976   3.044  1.00 41.80           C  
+ATOM    161  OD1 ASN A  21      -0.670  22.063   1.959  1.00 40.88           O  
+ATOM    162  ND2 ASN A  21      -0.546  21.172   3.988  1.00 40.69           N  
+ATOM    163  OXT ASN A  21       3.348  24.177   4.038  1.00 50.01           O  
+TER     164      ASN A  21                                                      
+ATOM    165  N   PHE B   1      16.351   9.416  -5.003  1.00 42.43           N  
+ATOM    166  CA  PHE B   1      14.858   9.235  -5.030  1.00 41.27           C  
+ATOM    167  C   PHE B   1      14.549   8.471  -6.308  1.00 41.80           C  
+ATOM    168  O   PHE B   1      15.318   8.544  -7.294  1.00 41.19           O  
+ATOM    169  CB  PHE B   1      14.113  10.542  -4.746  1.00 41.45           C  
+ATOM    170  CG  PHE B   1      12.731  10.401  -4.132  1.00 39.74           C  
+ATOM    171  CD1 PHE B   1      12.592  10.290  -2.768  1.00 40.24           C  
+ATOM    172  CD2 PHE B   1      11.613  10.333  -4.951  1.00 40.36           C  
+ATOM    173  CE1 PHE B   1      11.366  10.136  -2.140  1.00 40.51           C  
+ATOM    174  CE2 PHE B   1      10.338  10.161  -4.355  1.00 38.83           C  
+ATOM    175  CZ  PHE B   1      10.243  10.057  -2.970  1.00 40.48           C  
+ATOM    176  N   VAL B   2      13.476   7.675  -6.279  1.00 40.49           N  
+ATOM    177  CA  VAL B   2      13.047   6.894  -7.417  1.00 40.97           C  
+ATOM    178  C   VAL B   2      12.796   7.916  -8.541  1.00 43.34           C  
+ATOM    179  O   VAL B   2      12.379   9.066  -8.296  1.00 41.84           O  
+ATOM    180  CB  VAL B   2      11.771   6.064  -7.094  1.00 41.37           C  
+ATOM    181  CG1 VAL B   2      10.549   6.940  -6.977  1.00 39.22           C  
+ATOM    182  CG2 VAL B   2      11.473   4.947  -8.101  1.00 41.71           C  
+ATOM    183  N   ASN B   3      13.023   7.425  -9.738  1.00 45.51           N  
+ATOM    184  CA  ASN B   3      12.886   8.061 -11.031  1.00 47.98           C  
+ATOM    185  C   ASN B   3      11.838   7.284 -11.841  1.00 48.55           C  
+ATOM    186  O   ASN B   3      12.110   6.434 -12.721  1.00 48.14           O  
+ATOM    187  CB  ASN B   3      14.241   8.181 -11.730  1.00 50.26           C  
+ATOM    188  CG  ASN B   3      14.260   9.125 -12.910  1.00 52.83           C  
+ATOM    189  OD1 ASN B   3      14.112  10.368 -12.743  1.00 54.33           O  
+ATOM    190  ND2 ASN B   3      14.468   8.573 -14.122  1.00 53.52           N  
+ATOM    191  N   GLN B   4      10.582   7.627 -11.497  1.00 48.30           N  
+ATOM    192  CA  GLN B   4       9.485   6.951 -12.212  1.00 48.05           C  
+ATOM    193  C   GLN B   4       8.195   7.772 -12.225  1.00 46.68           C  
+ATOM    194  O   GLN B   4       8.087   8.740 -11.489  1.00 45.60           O  
+ATOM    195  CB  GLN B   4       9.199   5.545 -11.691  1.00 49.69           C  
+ATOM    196  CG  GLN B   4       9.084   5.306 -10.206  1.00 52.03           C  
+ATOM    197  CD  GLN B   4       7.961   4.316  -9.932  1.00 53.88           C  
+ATOM    198  OE1 GLN B   4       7.192   4.005 -10.854  1.00 56.03           O  
+ATOM    199  NE2 GLN B   4       7.855   3.817  -8.710  1.00 53.81           N  
+ATOM    200  N   HIS B   5       7.305   7.254 -13.065  1.00 45.02           N  
+ATOM    201  CA  HIS B   5       5.966   7.875 -13.172  1.00 43.46           C  
+ATOM    202  C   HIS B   5       5.305   7.482 -11.848  1.00 41.55           C  
+ATOM    203  O   HIS B   5       5.352   6.272 -11.567  1.00 40.76           O  
+ATOM    204  CB  HIS B   5       5.195   7.269 -14.346  1.00 44.45           C  
+ATOM    205  CG  HIS B   5       5.710   7.589 -15.721  1.00 46.74           C  
+ATOM    206  ND1 HIS B   5       5.316   8.669 -16.466  1.00 47.03           N  
+ATOM    207  CD2 HIS B   5       6.584   6.891 -16.515  1.00 47.06           C  
+ATOM    208  CE1 HIS B   5       5.919   8.651 -17.657  1.00 47.37           C  
+ATOM    209  NE2 HIS B   5       6.697   7.590 -17.690  1.00 47.30           N  
+ATOM    210  N   LEU B   6       4.786   8.374 -11.067  1.00 39.60           N  
+ATOM    211  CA  LEU B   6       4.090   8.181  -9.797  1.00 39.43           C  
+ATOM    212  C   LEU B   6       2.596   8.558 -10.016  1.00 38.97           C  
+ATOM    213  O   LEU B   6       2.157   9.716 -10.167  1.00 38.89           O  
+ATOM    214  CB  LEU B   6       4.818   8.957  -8.696  1.00 38.37           C  
+ATOM    215  CG  LEU B   6       6.211   8.496  -8.264  1.00 36.08           C  
+ATOM    216  CD1 LEU B   6       6.828   9.287  -7.136  1.00 36.29           C  
+ATOM    217  CD2 LEU B   6       6.089   7.040  -7.782  1.00 37.68           C  
+ATOM    218  N   CYS B   7       1.761   7.538  -9.991  1.00 38.42           N  
+ATOM    219  CA  CYS B   7       0.323   7.671 -10.261  1.00 38.14           C  
+ATOM    220  C   CYS B   7      -0.550   7.116  -9.164  1.00 36.94           C  
+ATOM    221  O   CYS B   7      -0.185   6.228  -8.423  1.00 35.02           O  
+ATOM    222  CB  CYS B   7       0.054   6.991 -11.596  1.00 39.09           C  
+ATOM    223  SG  CYS B   7       0.935   7.640 -13.006  1.00 41.34           S  
+ATOM    224  N   GLY B   8      -1.780   7.634  -9.110  1.00 37.02           N  
+ATOM    225  CA  GLY B   8      -2.792   7.265  -8.146  1.00 32.55           C  
+ATOM    226  C   GLY B   8      -2.355   7.336  -6.719  1.00 29.61           C  
+ATOM    227  O   GLY B   8      -1.799   8.277  -6.182  1.00 31.39           O  
+ATOM    228  N   SER B   9      -2.630   6.239  -5.979  1.00 27.53           N  
+ATOM    229  CA  SER B   9      -2.289   6.186  -4.556  1.00 25.22           C  
+ATOM    230  C   SER B   9      -0.758   6.218  -4.375  1.00 24.74           C  
+ATOM    231  O   SER B   9      -0.310   6.564  -3.302  1.00 25.36           O  
+ATOM    232  CB  SER B   9      -2.931   4.971  -3.844  1.00 27.86           C  
+ATOM    233  OG  SER B   9      -2.348   3.871  -4.522  1.00 27.40           O  
+ATOM    234  N   HIS B  10      -0.032   5.815  -5.373  1.00 25.24           N  
+ATOM    235  CA  HIS B  10       1.485   5.773  -5.283  1.00 26.30           C  
+ATOM    236  C   HIS B  10       1.990   7.253  -5.208  1.00 25.79           C  
+ATOM    237  O   HIS B  10       2.901   7.401  -4.425  1.00 25.64           O  
+ATOM    238  CB  HIS B  10       2.179   5.138  -6.456  1.00 26.39           C  
+ATOM    239  CG  HIS B  10       1.838   3.642  -6.449  1.00 28.42           C  
+ATOM    240  ND1 HIS B  10       2.103   2.865  -5.378  1.00 28.96           N  
+ATOM    241  CD2 HIS B  10       1.146   2.914  -7.356  1.00 27.85           C  
+ATOM    242  CE1 HIS B  10       1.638   1.649  -5.575  1.00 28.97           C  
+ATOM    243  NE2 HIS B  10       1.071   1.640  -6.737  1.00 28.46           N  
+ATOM    244  N   LEU B  11       1.356   8.122  -5.940  1.00 27.33           N  
+ATOM    245  CA  LEU B  11       1.666   9.578  -5.946  1.00 27.90           C  
+ATOM    246  C   LEU B  11       1.408  10.132  -4.592  1.00 27.57           C  
+ATOM    247  O   LEU B  11       2.245  10.860  -3.973  1.00 28.13           O  
+ATOM    248  CB  LEU B  11       0.852  10.239  -7.061  1.00 29.36           C  
+ATOM    249  CG  LEU B  11       1.039  11.733  -7.181  1.00 31.60           C  
+ATOM    250  CD1 LEU B  11       2.540  12.050  -7.130  1.00 29.90           C  
+ATOM    251  CD2 LEU B  11       0.391  12.170  -8.515  1.00 31.63           C  
+ATOM    252  N   VAL B  12       0.255   9.825  -3.961  1.00 25.20           N  
+ATOM    253  CA  VAL B  12      -0.118  10.285  -2.627  1.00 25.42           C  
+ATOM    254  C   VAL B  12       0.807   9.781  -1.553  1.00 25.59           C  
+ATOM    255  O   VAL B  12       1.153  10.480  -0.542  1.00 25.06           O  
+ATOM    256  CB  VAL B  12      -1.650   9.952  -2.483  1.00 26.87           C  
+ATOM    257  CG1 VAL B  12      -2.226  10.182  -1.128  1.00 28.10           C  
+ATOM    258  CG2 VAL B  12      -2.445  10.742  -3.495  1.00 28.14           C  
+ATOM    259  N   GLU B  13       1.200   8.470  -1.636  1.00 25.31           N  
+ATOM    260  CA  GLU B  13       2.099   8.028  -0.537  1.00 25.61           C  
+ATOM    261  C   GLU B  13       3.424   8.765  -0.744  1.00 24.60           C  
+ATOM    262  O   GLU B  13       3.954   8.956   0.327  1.00 25.37           O  
+ATOM    263  CB  GLU B  13       2.265   6.507  -0.609  1.00 29.03           C  
+ATOM    264  CG AGLU B  13       2.267   5.624   0.611  0.50 31.12           C  
+ATOM    265  CG BGLU B  13       0.911   5.831  -0.262  0.50 30.89           C  
+ATOM    266  CD AGLU B  13       2.900   5.917   1.912  0.50 33.15           C  
+ATOM    267  CD BGLU B  13       0.479   6.025   1.168  0.50 31.39           C  
+ATOM    268  OE1AGLU B  13       4.079   5.948   2.257  0.50 34.10           O  
+ATOM    269  OE1BGLU B  13       1.291   5.950   2.059  0.50 32.33           O  
+ATOM    270  OE2AGLU B  13       2.039   6.116   2.806  0.50 34.69           O  
+ATOM    271  OE2BGLU B  13      -0.715   6.239   1.428  0.50 32.18           O  
+ATOM    272  N   ALA B  14       3.883   9.007  -1.941  1.00 24.76           N  
+ATOM    273  CA  ALA B  14       5.167   9.727  -2.226  1.00 25.79           C  
+ATOM    274  C   ALA B  14       5.103  11.085  -1.523  1.00 27.25           C  
+ATOM    275  O   ALA B  14       6.006  11.474  -0.800  1.00 27.84           O  
+ATOM    276  CB  ALA B  14       5.381   9.833  -3.720  1.00 24.90           C  
+ATOM    277  N   LEU B  15       3.976  11.795  -1.769  1.00 28.40           N  
+ATOM    278  CA  LEU B  15       3.714  13.105  -1.134  1.00 28.29           C  
+ATOM    279  C   LEU B  15       3.783  13.062   0.375  1.00 26.69           C  
+ATOM    280  O   LEU B  15       4.448  13.899   1.024  1.00 25.47           O  
+ATOM    281  CB  LEU B  15       2.379  13.773  -1.588  1.00 28.79           C  
+ATOM    282  CG  LEU B  15       2.316  14.354  -2.978  1.00 32.77           C  
+ATOM    283  CD1 LEU B  15       0.870  14.660  -3.366  1.00 33.83           C  
+ATOM    284  CD2 LEU B  15       3.163  15.661  -3.002  1.00 32.91           C  
+ATOM    285  N   TYR B  16       3.045  12.126   1.002  1.00 26.90           N  
+ATOM    286  CA  TYR B  16       2.977  11.892   2.410  1.00 27.31           C  
+ATOM    287  C   TYR B  16       4.390  11.788   3.050  1.00 27.40           C  
+ATOM    288  O   TYR B  16       4.707  12.365   4.118  1.00 28.62           O  
+ATOM    289  CB  TYR B  16       2.189  10.532   2.668  1.00 26.54           C  
+ATOM    290  CG  TYR B  16       1.990  10.338   4.157  1.00 26.57           C  
+ATOM    291  CD1 TYR B  16       1.099  11.105   4.895  1.00 28.08           C  
+ATOM    292  CD2 TYR B  16       2.676   9.326   4.841  1.00 27.15           C  
+ATOM    293  CE1 TYR B  16       0.931  10.935   6.253  1.00 30.02           C  
+ATOM    294  CE2 TYR B  16       2.548   9.127   6.222  1.00 27.12           C  
+ATOM    295  CZ  TYR B  16       1.673   9.920   6.914  1.00 29.08           C  
+ATOM    296  OH  TYR B  16       1.494   9.784   8.274  1.00 30.04           O  
+ATOM    297  N   LEU B  17       5.158  10.917   2.381  1.00 27.43           N  
+ATOM    298  CA  LEU B  17       6.553  10.695   2.857  1.00 29.81           C  
+ATOM    299  C   LEU B  17       7.438  11.926   2.668  1.00 29.18           C  
+ATOM    300  O   LEU B  17       8.170  12.248   3.603  1.00 30.39           O  
+ATOM    301  CB  LEU B  17       7.174   9.565   1.990  1.00 29.51           C  
+ATOM    302  CG  LEU B  17       8.648   9.317   2.320  1.00 32.54           C  
+ATOM    303  CD1 LEU B  17       8.704   8.646   3.669  1.00 33.28           C  
+ATOM    304  CD2 LEU B  17       9.186   8.419   1.226  1.00 33.73           C  
+ATOM    305  N   VAL B  18       7.446  12.524   1.537  1.00 30.66           N  
+ATOM    306  CA  VAL B  18       8.307  13.681   1.240  1.00 34.36           C  
+ATOM    307  C   VAL B  18       7.974  14.925   2.044  1.00 34.55           C  
+ATOM    308  O   VAL B  18       8.935  15.584   2.459  1.00 35.26           O  
+ATOM    309  CB  VAL B  18       8.352  14.051  -0.265  1.00 35.12           C  
+ATOM    310  CG1 VAL B  18       8.972  15.449  -0.523  1.00 36.94           C  
+ATOM    311  CG2 VAL B  18       9.141  13.056  -1.102  1.00 35.46           C  
+ATOM    312  N   CYS B  19       6.726  15.215   2.271  1.00 33.94           N  
+ATOM    313  CA  CYS B  19       6.226  16.407   2.928  1.00 34.32           C  
+ATOM    314  C   CYS B  19       6.218  16.360   4.416  1.00 37.32           C  
+ATOM    315  O   CYS B  19       6.272  17.466   4.990  1.00 38.97           O  
+ATOM    316  CB  CYS B  19       4.868  16.863   2.346  1.00 30.02           C  
+ATOM    317  SG  CYS B  19       4.895  17.085   0.607  1.00 30.07           S  
+ATOM    318  N   GLY B  20       6.215  15.182   4.978  1.00 39.35           N  
+ATOM    319  CA  GLY B  20       6.215  15.022   6.425  1.00 42.40           C  
+ATOM    320  C   GLY B  20       5.142  15.872   7.085  1.00 44.09           C  
+ATOM    321  O   GLY B  20       3.978  15.909   6.623  1.00 44.41           O  
+ATOM    322  N   GLU B  21       5.576  16.483   8.167  1.00 45.78           N  
+ATOM    323  CA  GLU B  21       4.762  17.324   9.036  1.00 48.85           C  
+ATOM    324  C   GLU B  21       4.197  18.575   8.391  1.00 46.95           C  
+ATOM    325  O   GLU B  21       3.291  19.146   9.020  1.00 48.08           O  
+ATOM    326  CB  GLU B  21       5.491  17.697  10.355  1.00 52.43           C  
+ATOM    327  CG  GLU B  21       6.380  16.636  10.968  1.00 55.99           C  
+ATOM    328  CD  GLU B  21       7.291  16.898  12.127  1.00 58.37           C  
+ATOM    329  OE1 GLU B  21       6.925  17.489  13.144  1.00 59.90           O  
+ATOM    330  OE2 GLU B  21       8.463  16.448  11.958  1.00 59.41           O  
+ATOM    331  N   ARG B  22       4.617  18.958   7.204  1.00 45.12           N  
+ATOM    332  CA  ARG B  22       4.132  20.090   6.459  1.00 42.85           C  
+ATOM    333  C   ARG B  22       2.694  19.800   5.978  1.00 42.98           C  
+ATOM    334  O   ARG B  22       1.734  20.626   6.085  1.00 40.81           O  
+ATOM    335  CB  ARG B  22       4.949  20.425   5.203  1.00 44.07           C  
+ATOM    336  CG  ARG B  22       6.238  21.195   5.558  1.00 44.50           C  
+ATOM    337  CD  ARG B  22       6.973  21.546   4.305  1.00 46.05           C  
+ATOM    338  NE  ARG B  22       8.056  20.605   4.062  1.00 45.60           N  
+ATOM    339  CZ  ARG B  22       8.575  20.512   2.837  1.00 47.31           C  
+ATOM    340  NH1 ARG B  22       8.184  21.303   1.843  1.00 46.88           N  
+ATOM    341  NH2 ARG B  22       9.451  19.516   2.597  1.00 47.44           N  
+ATOM    342  N   GLY B  23       2.670  18.565   5.442  1.00 38.63           N  
+ATOM    343  CA  GLY B  23       1.404  18.032   4.880  1.00 35.03           C  
+ATOM    344  C   GLY B  23       1.493  18.421   3.409  1.00 32.62           C  
+ATOM    345  O   GLY B  23       2.560  18.961   3.019  1.00 32.76           O  
+ATOM    346  N   PHE B  24       0.407  18.214   2.653  1.00 30.03           N  
+ATOM    347  CA  PHE B  24       0.434  18.486   1.218  1.00 29.17           C  
+ATOM    348  C   PHE B  24      -0.977  18.758   0.717  1.00 28.94           C  
+ATOM    349  O   PHE B  24      -1.930  18.598   1.509  1.00 30.11           O  
+ATOM    350  CB  PHE B  24       1.082  17.278   0.462  1.00 30.36           C  
+ATOM    351  CG  PHE B  24       0.387  15.943   0.727  1.00 29.85           C  
+ATOM    352  CD1 PHE B  24       0.646  15.201   1.853  1.00 29.66           C  
+ATOM    353  CD2 PHE B  24      -0.575  15.527  -0.213  1.00 30.40           C  
+ATOM    354  CE1 PHE B  24       0.004  13.999   2.126  1.00 29.30           C  
+ATOM    355  CE2 PHE B  24      -1.231  14.283   0.048  1.00 29.85           C  
+ATOM    356  CZ  PHE B  24      -0.933  13.513   1.184  1.00 29.18           C  
+ATOM    357  N   PHE B  25      -1.011  19.068  -0.537  1.00 29.49           N  
+ATOM    358  CA  PHE B  25      -2.330  19.268  -1.184  1.00 30.79           C  
+ATOM    359  C   PHE B  25      -2.280  18.385  -2.414  1.00 31.99           C  
+ATOM    360  O   PHE B  25      -1.293  18.318  -3.170  1.00 32.57           O  
+ATOM    361  CB  PHE B  25      -2.551  20.770  -1.446  1.00 32.23           C  
+ATOM    362  CG  PHE B  25      -1.654  21.468  -2.445  1.00 32.03           C  
+ATOM    363  CD1 PHE B  25      -1.936  21.439  -3.819  1.00 31.89           C  
+ATOM    364  CD2 PHE B  25      -0.533  22.148  -2.003  1.00 33.58           C  
+ATOM    365  CE1 PHE B  25      -1.109  22.099  -4.726  1.00 33.32           C  
+ATOM    366  CE2 PHE B  25       0.298  22.793  -2.915  1.00 32.03           C  
+ATOM    367  CZ  PHE B  25       0.015  22.789  -4.290  1.00 32.35           C  
+ATOM    368  N   TYR B  26      -3.370  17.597  -2.640  1.00 31.19           N  
+ATOM    369  CA  TYR B  26      -3.472  16.727  -3.815  1.00 32.39           C  
+ATOM    370  C   TYR B  26      -4.673  17.233  -4.648  1.00 34.05           C  
+ATOM    371  O   TYR B  26      -5.824  17.004  -4.237  1.00 36.02           O  
+ATOM    372  CB  TYR B  26      -3.687  15.256  -3.365  1.00 31.03           C  
+ATOM    373  CG  TYR B  26      -3.815  14.414  -4.599  1.00 31.88           C  
+ATOM    374  CD1 TYR B  26      -2.763  14.122  -5.470  1.00 32.91           C  
+ATOM    375  CD2 TYR B  26      -5.034  13.773  -4.848  1.00 33.25           C  
+ATOM    376  CE1 TYR B  26      -2.955  13.328  -6.624  1.00 34.42           C  
+ATOM    377  CE2 TYR B  26      -5.202  12.971  -5.972  1.00 33.66           C  
+ATOM    378  CZ  TYR B  26      -4.178  12.738  -6.862  1.00 35.18           C  
+ATOM    379  OH  TYR B  26      -4.444  11.928  -7.947  1.00 35.97           O  
+ATOM    380  N   THR B  27      -4.461  17.866  -5.738  1.00 35.70           N  
+ATOM    381  CA  THR B  27      -5.519  18.448  -6.612  1.00 39.87           C  
+ATOM    382  C   THR B  27      -5.225  17.968  -8.018  1.00 43.21           C  
+ATOM    383  O   THR B  27      -4.484  18.537  -8.866  1.00 44.55           O  
+ATOM    384  CB  THR B  27      -5.615  19.988  -6.175  1.00 39.67           C  
+ATOM    385  OG1 THR B  27      -4.364  20.649  -6.442  1.00 41.28           O  
+ATOM    386  CG2 THR B  27      -5.871  20.295  -4.672  1.00 36.78           C  
+ATOM    387  N   PRO B  28      -5.788  16.784  -8.351  1.00 46.37           N  
+ATOM    388  CA  PRO B  28      -5.554  16.125  -9.648  1.00 48.85           C  
+ATOM    389  C   PRO B  28      -6.370  16.725 -10.772  1.00 53.33           C  
+ATOM    390  O   PRO B  28      -6.144  16.355 -11.945  1.00 53.91           O  
+ATOM    391  CB  PRO B  28      -5.981  14.677  -9.394  1.00 48.86           C  
+ATOM    392  CG  PRO B  28      -7.149  14.854  -8.438  1.00 47.73           C  
+ATOM    393  CD  PRO B  28      -6.634  15.940  -7.490  1.00 46.52           C  
+ATOM    394  N   LYS B  29      -7.299  17.578 -10.331  1.00 56.78           N  
+ATOM    395  CA  LYS B  29      -8.175  18.206 -11.342  1.00 61.80           C  
+ATOM    396  C   LYS B  29      -7.241  18.953 -12.292  1.00 64.20           C  
+ATOM    397  O   LYS B  29      -6.529  19.927 -12.008  1.00 64.95           O  
+ATOM    398  CB  LYS B  29      -9.321  18.987 -10.740  1.00 62.57           C  
+ATOM    399  CG  LYS B  29     -10.652  18.207 -10.832  1.00 63.44           C  
+ATOM    400  CD  LYS B  29     -11.215  18.215 -12.255  1.00 63.65           C  
+ATOM    401  CE  LYS B  29     -10.500  17.259 -13.187  1.00 63.84           C  
+ATOM    402  NZ  LYS B  29     -10.528  17.668 -14.610  1.00 63.61           N  
+ATOM    403  N   THR B  30      -7.253  18.367 -13.481  1.00 66.91           N  
+ATOM    404  CA  THR B  30      -6.464  18.737 -14.651  1.00 68.92           C  
+ATOM    405  C   THR B  30      -7.089  19.763 -15.592  1.00 70.29           C  
+ATOM    406  O   THR B  30      -8.345  19.656 -15.750  1.00 71.80           O  
+ATOM    407  CB  THR B  30      -6.131  17.396 -15.441  1.00 68.75           C  
+ATOM    408  OXT THR B  30      -6.314  20.359 -16.384  1.00 71.09           O  
+TER     409      THR B  30                                                      
+ATOM    410  N   GLY C   1      -7.763  16.810  14.450  1.00 50.00           N  
+ATOM    411  CA  GLY C   1      -8.349  16.758  13.102  1.00 49.60           C  
+ATOM    412  C   GLY C   1      -8.559  15.310  12.680  1.00 48.62           C  
+ATOM    413  O   GLY C   1      -9.040  14.506  13.510  1.00 48.82           O  
+ATOM    414  N   ILE C   2      -8.160  15.017  11.441  1.00 48.24           N  
+ATOM    415  CA  ILE C   2      -8.380  13.660  10.916  1.00 46.81           C  
+ATOM    416  C   ILE C   2      -7.641  12.614  11.707  1.00 46.59           C  
+ATOM    417  O   ILE C   2      -8.103  11.484  11.878  1.00 44.63           O  
+ATOM    418  CB  ILE C   2      -8.127  13.574   9.372  1.00 47.01           C  
+ATOM    419  CG1 ILE C   2      -8.652  12.227   8.798  1.00 46.19           C  
+ATOM    420  CG2 ILE C   2      -6.627  13.824   9.020  1.00 48.29           C  
+ATOM    421  CD1 ILE C   2      -8.650  12.139   7.244  1.00 43.40           C  
+ATOM    422  N   VAL C   3      -6.500  13.053  12.196  1.00 48.39           N  
+ATOM    423  CA  VAL C   3      -5.656  12.098  12.957  1.00 50.75           C  
+ATOM    424  C   VAL C   3      -6.227  11.778  14.316  1.00 51.84           C  
+ATOM    425  O   VAL C   3      -6.158  10.584  14.672  1.00 51.95           O  
+ATOM    426  CB  VAL C   3      -4.173  12.500  12.784  1.00 50.95           C  
+ATOM    427  CG1 VAL C   3      -3.242  11.594  13.569  1.00 49.85           C  
+ATOM    428  CG2 VAL C   3      -3.811  12.462  11.294  1.00 50.46           C  
+ATOM    429  N   GLU C   4      -6.782  12.708  15.060  1.00 53.72           N  
+ATOM    430  CA  GLU C   4      -7.359  12.397  16.385  1.00 55.53           C  
+ATOM    431  C   GLU C   4      -8.685  11.635  16.215  1.00 54.37           C  
+ATOM    432  O   GLU C   4      -9.073  10.717  16.973  1.00 54.38           O  
+ATOM    433  CB  GLU C   4      -7.661  13.614  17.256  1.00 58.09           C  
+ATOM    434  CG  GLU C   4      -7.028  14.993  17.113  1.00 61.61           C  
+ATOM    435  CD  GLU C   4      -5.607  15.051  16.621  1.00 63.57           C  
+ATOM    436  OE1 GLU C   4      -4.833  14.138  16.925  1.00 65.17           O  
+ATOM    437  OE2 GLU C   4      -5.251  16.011  15.885  1.00 64.88           O  
+ATOM    438  N   GLN C   5      -9.408  12.059  15.191  1.00 53.11           N  
+ATOM    439  CA  GLN C   5     -10.710  11.479  14.880  1.00 51.57           C  
+ATOM    440  C   GLN C   5     -10.579  10.088  14.293  1.00 50.38           C  
+ATOM    441  O   GLN C   5     -11.163   9.159  14.908  1.00 50.44           O  
+ATOM    442  CB  GLN C   5     -11.540  12.435  14.023  1.00 52.73           C  
+ATOM    443  CG  GLN C   5     -12.860  11.939  13.531  1.00 53.39           C  
+ATOM    444  CD  GLN C   5     -13.941  12.631  12.779  1.00 54.04           C  
+ATOM    445  OE1 GLN C   5     -13.929  13.413  11.823  1.00 53.27           O  
+ATOM    446  NE2 GLN C   5     -15.170  12.282  13.239  1.00 54.68           N  
+ATOM    447  N   CYS C   6      -9.865   9.927  13.192  1.00 48.69           N  
+ATOM    448  CA  CYS C   6      -9.759   8.612  12.502  1.00 46.22           C  
+ATOM    449  C   CYS C   6      -8.712   7.586  12.845  1.00 46.69           C  
+ATOM    450  O   CYS C   6      -8.736   6.445  12.335  1.00 44.40           O  
+ATOM    451  CB  CYS C   6      -9.735   8.963  11.008  1.00 44.82           C  
+ATOM    452  SG  CYS C   6     -11.172  10.012  10.566  1.00 43.15           S  
+ATOM    453  N   CYS C   7      -7.805   7.939  13.742  1.00 47.19           N  
+ATOM    454  CA  CYS C   7      -6.760   6.974  14.150  1.00 49.60           C  
+ATOM    455  C   CYS C   7      -7.254   6.180  15.354  1.00 52.71           C  
+ATOM    456  O   CYS C   7      -7.191   4.916  15.379  1.00 54.88           O  
+ATOM    457  CB  CYS C   7      -5.406   7.675  14.215  1.00 45.99           C  
+ATOM    458  SG  CYS C   7      -4.824   8.119  12.551  1.00 42.34           S  
+ATOM    459  N   THR C   8      -7.818   6.927  16.283  1.00 56.56           N  
+ATOM    460  CA  THR C   8      -8.419   6.515  17.539  1.00 58.89           C  
+ATOM    461  C   THR C   8      -9.486   5.408  17.389  1.00 59.05           C  
+ATOM    462  O   THR C   8      -9.545   4.360  18.040  1.00 60.38           O  
+ATOM    463  CB  THR C   8      -9.313   7.652  18.223  1.00 59.69           C  
+ATOM    464  OG1 THR C   8      -8.576   8.889  18.352  1.00 60.33           O  
+ATOM    465  CG2 THR C   8      -9.906   7.110  19.553  1.00 60.92           C  
+ATOM    466  N   SER C   9     -10.386   5.837  16.528  1.00 58.88           N  
+ATOM    467  CA  SER C   9     -11.595   5.146  16.100  1.00 57.50           C  
+ATOM    468  C   SER C   9     -11.690   5.263  14.574  1.00 55.74           C  
+ATOM    469  O   SER C   9     -11.280   6.297  13.994  1.00 56.06           O  
+ATOM    470  CB  SER C   9     -12.821   5.752  16.784  1.00 58.67           C  
+ATOM    471  OG  SER C   9     -13.192   6.991  16.200  1.00 60.20           O  
+ATOM    472  N   ILE C  10     -12.235   4.185  14.038  1.00 52.77           N  
+ATOM    473  CA  ILE C  10     -12.379   4.156  12.563  1.00 51.16           C  
+ATOM    474  C   ILE C  10     -13.517   5.077  12.144  1.00 48.68           C  
+ATOM    475  O   ILE C  10     -14.548   5.220  12.816  1.00 47.95           O  
+ATOM    476  CB  ILE C  10     -12.359   2.664  12.123  1.00 51.99           C  
+ATOM    477  CG1 ILE C  10     -13.509   2.431  11.138  1.00 52.97           C  
+ATOM    478  CG2 ILE C  10     -12.324   1.724  13.361  1.00 53.14           C  
+ATOM    479  CD1 ILE C  10     -13.646   1.070  10.412  1.00 54.35           C  
+ATOM    480  N   CYS C  11     -13.287   5.769  11.069  1.00 44.60           N  
+ATOM    481  CA  CYS C  11     -14.124   6.717  10.401  1.00 41.76           C  
+ATOM    482  C   CYS C  11     -14.673   5.968   9.198  1.00 41.21           C  
+ATOM    483  O   CYS C  11     -13.961   5.173   8.578  1.00 42.15           O  
+ATOM    484  CB  CYS C  11     -13.420   7.968   9.920  1.00 41.84           C  
+ATOM    485  SG  CYS C  11     -12.724   8.926  11.247  1.00 41.48           S  
+ATOM    486  N   SER C  12     -15.919   6.226   8.920  1.00 38.05           N  
+ATOM    487  CA  SER C  12     -16.676   5.659   7.811  1.00 34.47           C  
+ATOM    488  C   SER C  12     -16.304   6.435   6.592  1.00 32.70           C  
+ATOM    489  O   SER C  12     -15.618   7.476   6.833  1.00 33.11           O  
+ATOM    490  CB  SER C  12     -18.188   5.919   8.145  1.00 34.81           C  
+ATOM    491  OG  SER C  12     -18.461   7.310   8.270  1.00 31.44           O  
+ATOM    492  N   LEU C  13     -16.671   6.118   5.396  1.00 33.14           N  
+ATOM    493  CA  LEU C  13     -16.412   6.823   4.158  1.00 33.44           C  
+ATOM    494  C   LEU C  13     -17.152   8.194   4.266  1.00 34.65           C  
+ATOM    495  O   LEU C  13     -16.602   9.082   3.590  1.00 32.99           O  
+ATOM    496  CB  LEU C  13     -16.885   6.080   2.890  1.00 35.67           C  
+ATOM    497  CG ALEU C  13     -17.019   6.846   1.596  0.50 36.10           C  
+ATOM    498  CG BLEU C  13     -16.091   4.812   2.554  0.50 34.53           C  
+ATOM    499  CD1ALEU C  13     -17.124   6.002   0.325  0.50 36.33           C  
+ATOM    500  CD1BLEU C  13     -15.646   4.737   1.101  0.50 35.14           C  
+ATOM    501  CD2ALEU C  13     -18.291   7.710   1.600  0.50 37.21           C  
+ATOM    502  CD2BLEU C  13     -14.785   4.746   3.345  0.50 35.34           C  
+ATOM    503  N   TYR C  14     -18.250   8.197   5.013  1.00 33.10           N  
+ATOM    504  CA  TYR C  14     -19.079   9.391   5.198  1.00 33.92           C  
+ATOM    505  C   TYR C  14     -18.341  10.399   6.044  1.00 32.35           C  
+ATOM    506  O   TYR C  14     -18.451  11.577   5.680  1.00 33.52           O  
+ATOM    507  CB  TYR C  14     -20.465   9.078   5.896  1.00 34.61           C  
+ATOM    508  CG  TYR C  14     -21.063   8.016   5.020  1.00 37.25           C  
+ATOM    509  CD1 TYR C  14     -21.580   8.389   3.778  1.00 39.07           C  
+ATOM    510  CD2 TYR C  14     -20.937   6.667   5.309  1.00 38.74           C  
+ATOM    511  CE1 TYR C  14     -22.076   7.450   2.881  1.00 41.70           C  
+ATOM    512  CE2 TYR C  14     -21.451   5.708   4.440  1.00 40.82           C  
+ATOM    513  CZ  TYR C  14     -21.998   6.099   3.249  1.00 41.89           C  
+ATOM    514  OH  TYR C  14     -22.484   5.144   2.365  1.00 46.44           O  
+ATOM    515  N   GLN C  15     -17.688   9.935   7.087  1.00 32.96           N  
+ATOM    516  CA  GLN C  15     -16.896  10.826   7.942  1.00 33.99           C  
+ATOM    517  C   GLN C  15     -15.659  11.306   7.179  1.00 35.53           C  
+ATOM    518  O   GLN C  15     -15.332  12.500   7.275  1.00 34.85           O  
+ATOM    519  CB  GLN C  15     -16.531  10.274   9.294  1.00 35.14           C  
+ATOM    520  CG  GLN C  15     -17.666  10.040  10.266  1.00 37.18           C  
+ATOM    521  CD  GLN C  15     -17.218   9.158  11.384  1.00 40.42           C  
+ATOM    522  OE1 GLN C  15     -16.842   7.992  11.180  1.00 41.84           O  
+ATOM    523  NE2 GLN C  15     -17.225   9.644  12.627  1.00 41.89           N  
+ATOM    524  N   LEU C  16     -15.009  10.418   6.370  1.00 34.41           N  
+ATOM    525  CA  LEU C  16     -13.845  10.815   5.597  1.00 33.50           C  
+ATOM    526  C   LEU C  16     -14.102  11.888   4.581  1.00 33.76           C  
+ATOM    527  O   LEU C  16     -13.225  12.751   4.306  1.00 33.30           O  
+ATOM    528  CB  LEU C  16     -13.284   9.529   4.878  1.00 30.45           C  
+ATOM    529  CG  LEU C  16     -12.716   8.591   5.920  1.00 31.72           C  
+ATOM    530  CD1 LEU C  16     -12.420   7.232   5.216  1.00 31.52           C  
+ATOM    531  CD2 LEU C  16     -11.399   9.038   6.527  1.00 32.79           C  
+ATOM    532  N   GLU C  17     -15.295  11.797   4.024  1.00 32.39           N  
+ATOM    533  CA  GLU C  17     -15.753  12.767   3.008  1.00 34.73           C  
+ATOM    534  C   GLU C  17     -15.742  14.213   3.530  1.00 31.80           C  
+ATOM    535  O   GLU C  17     -15.630  15.101   2.700  1.00 30.97           O  
+ATOM    536  CB  GLU C  17     -17.104  12.429   2.478  1.00 37.24           C  
+ATOM    537  CG  GLU C  17     -17.439  12.477   0.997  1.00 41.46           C  
+ATOM    538  CD  GLU C  17     -18.928  12.238   0.812  1.00 42.29           C  
+ATOM    539  OE1 GLU C  17     -19.681  12.052   1.750  1.00 43.66           O  
+ATOM    540  OE2 GLU C  17     -19.169  12.249  -0.391  1.00 44.08           O  
+ATOM    541  N   ASN C  18     -15.797  14.400   4.792  1.00 33.54           N  
+ATOM    542  CA  ASN C  18     -15.769  15.674   5.517  1.00 35.09           C  
+ATOM    543  C   ASN C  18     -14.500  16.446   5.178  1.00 36.96           C  
+ATOM    544  O   ASN C  18     -14.460  17.667   4.986  1.00 35.15           O  
+ATOM    545  CB  ASN C  18     -15.868  15.484   7.054  1.00 36.18           C  
+ATOM    546  CG  ASN C  18     -17.351  15.375   7.362  1.00 37.35           C  
+ATOM    547  OD1 ASN C  18     -18.076  15.820   6.431  1.00 39.03           O  
+ATOM    548  ND2 ASN C  18     -17.825  14.781   8.440  1.00 39.47           N  
+ATOM    549  N   TYR C  19     -13.435  15.609   5.059  1.00 36.15           N  
+ATOM    550  CA  TYR C  19     -12.102  16.183   4.742  1.00 35.38           C  
+ATOM    551  C   TYR C  19     -11.768  16.394   3.313  1.00 35.49           C  
+ATOM    552  O   TYR C  19     -10.601  16.778   3.093  1.00 37.19           O  
+ATOM    553  CB  TYR C  19     -11.063  15.265   5.420  1.00 35.86           C  
+ATOM    554  CG  TYR C  19     -11.258  15.146   6.901  1.00 37.15           C  
+ATOM    555  CD1 TYR C  19     -10.827  16.150   7.758  1.00 38.25           C  
+ATOM    556  CD2 TYR C  19     -11.811  14.031   7.488  1.00 38.18           C  
+ATOM    557  CE1 TYR C  19     -10.994  16.080   9.151  1.00 39.05           C  
+ATOM    558  CE2 TYR C  19     -11.984  13.930   8.850  1.00 39.45           C  
+ATOM    559  CZ  TYR C  19     -11.587  14.951   9.698  1.00 39.85           C  
+ATOM    560  OH  TYR C  19     -11.728  14.749  11.045  1.00 39.91           O  
+ATOM    561  N   CYS C  20     -12.600  16.178   2.329  1.00 35.67           N  
+ATOM    562  CA  CYS C  20     -12.319  16.348   0.923  1.00 35.10           C  
+ATOM    563  C   CYS C  20     -12.372  17.874   0.623  1.00 37.31           C  
+ATOM    564  O   CYS C  20     -12.873  18.577   1.491  1.00 40.48           O  
+ATOM    565  CB  CYS C  20     -13.216  15.580  -0.043  1.00 32.48           C  
+ATOM    566  SG  CYS C  20     -13.270  13.771   0.268  1.00 32.80           S  
+ATOM    567  N   ASN C  21     -11.955  18.246  -0.546  1.00 38.97           N  
+ATOM    568  CA  ASN C  21     -12.037  19.624  -0.988  1.00 42.66           C  
+ATOM    569  C   ASN C  21     -13.538  19.808  -1.363  1.00 45.63           C  
+ATOM    570  O   ASN C  21     -14.011  20.894  -0.919  1.00 48.51           O  
+ATOM    571  CB  ASN C  21     -11.162  19.964  -2.173  1.00 42.65           C  
+ATOM    572  CG  ASN C  21      -9.741  20.231  -1.720  1.00 43.69           C  
+ATOM    573  OD1 ASN C  21      -8.822  19.998  -2.520  1.00 45.56           O  
+ATOM    574  ND2 ASN C  21      -9.598  20.621  -0.467  1.00 43.79           N  
+ATOM    575  OXT ASN C  21     -14.066  18.891  -2.019  1.00 46.37           O  
+TER     576      ASN C  21                                                      
+ATOM    577  N   ASN D   3       0.508   4.994  16.891  1.00 43.99           N  
+ATOM    578  CA  ASN D   3       1.543   5.461  15.949  1.00 43.37           C  
+ATOM    579  C   ASN D   3       0.807   6.186  14.806  1.00 42.65           C  
+ATOM    580  O   ASN D   3       0.428   5.553  13.829  1.00 42.18           O  
+ATOM    581  CB  ASN D   3       2.504   4.453  15.379  1.00 44.99           C  
+ATOM    582  CG  ASN D   3       3.652   5.003  14.563  1.00 46.10           C  
+ATOM    583  OD1 ASN D   3       3.562   5.895  13.691  1.00 47.23           O  
+ATOM    584  ND2 ASN D   3       4.891   4.494  14.721  1.00 48.27           N  
+ATOM    585  N   GLN D   4       0.710   7.462  15.056  1.00 41.30           N  
+ATOM    586  CA  GLN D   4       0.048   8.422  14.186  1.00 40.51           C  
+ATOM    587  C   GLN D   4       0.653   8.457  12.786  1.00 36.81           C  
+ATOM    588  O   GLN D   4      -0.114   8.795  11.880  1.00 32.96           O  
+ATOM    589  CB  GLN D   4       0.175   9.798  14.849  1.00 43.51           C  
+ATOM    590  CG  GLN D   4      -1.133  10.570  14.881  1.00 46.90           C  
+ATOM    591  CD  GLN D   4      -1.269  11.554  16.037  1.00 47.63           C  
+ATOM    592  OE1 GLN D   4      -1.887  11.174  17.036  1.00 49.48           O  
+ATOM    593  NE2 GLN D   4      -0.734  12.772  15.908  1.00 48.09           N  
+ATOM    594  N   HIS D   5       1.978   8.191  12.740  1.00 32.23           N  
+ATOM    595  CA  HIS D   5       2.637   8.201  11.454  1.00 32.58           C  
+ATOM    596  C   HIS D   5       2.096   7.048  10.569  1.00 29.87           C  
+ATOM    597  O   HIS D   5       1.857   7.234   9.363  1.00 28.90           O  
+ATOM    598  CB  HIS D   5       4.204   8.044  11.551  1.00 34.68           C  
+ATOM    599  CG  HIS D   5       4.936   8.392  10.299  1.00 37.96           C  
+ATOM    600  ND1 HIS D   5       5.882   7.584   9.678  1.00 39.53           N  
+ATOM    601  CD2 HIS D   5       4.775   9.476   9.491  1.00 38.21           C  
+ATOM    602  CE1 HIS D   5       6.274   8.170   8.539  1.00 40.07           C  
+ATOM    603  NE2 HIS D   5       5.597   9.328   8.407  1.00 39.92           N  
+ATOM    604  N   LEU D   6       2.012   5.886  11.165  1.00 27.66           N  
+ATOM    605  CA  LEU D   6       1.553   4.693  10.411  1.00 28.47           C  
+ATOM    606  C   LEU D   6       0.090   4.848  10.040  1.00 26.57           C  
+ATOM    607  O   LEU D   6      -0.253   4.545   8.912  1.00 26.41           O  
+ATOM    608  CB  LEU D   6       1.909   3.379  11.157  1.00 28.19           C  
+ATOM    609  CG  LEU D   6       3.405   3.136  11.464  1.00 30.43           C  
+ATOM    610  CD1 LEU D   6       3.591   1.920  12.332  1.00 30.38           C  
+ATOM    611  CD2 LEU D   6       4.174   2.929  10.142  1.00 30.80           C  
+ATOM    612  N   CYS D   7      -0.680   5.362  10.984  1.00 28.13           N  
+ATOM    613  CA  CYS D   7      -2.110   5.558  10.734  1.00 30.31           C  
+ATOM    614  C   CYS D   7      -2.330   6.530   9.568  1.00 27.83           C  
+ATOM    615  O   CYS D   7      -3.114   6.360   8.650  1.00 25.89           O  
+ATOM    616  CB  CYS D   7      -2.707   6.118  12.036  1.00 33.89           C  
+ATOM    617  SG  CYS D   7      -4.495   6.309  11.670  1.00 37.21           S  
+ATOM    618  N   GLY D   8      -1.516   7.558   9.573  1.00 27.92           N  
+ATOM    619  CA  GLY D   8      -1.513   8.636   8.563  1.00 28.19           C  
+ATOM    620  C   GLY D   8      -1.354   8.119   7.158  1.00 26.10           C  
+ATOM    621  O   GLY D   8      -2.019   8.596   6.209  1.00 27.25           O  
+ATOM    622  N   SER D   9      -0.419   7.151   6.966  1.00 26.24           N  
+ATOM    623  CA  SER D   9      -0.244   6.536   5.655  1.00 26.25           C  
+ATOM    624  C   SER D   9      -1.530   5.916   5.124  1.00 25.09           C  
+ATOM    625  O   SER D   9      -1.849   6.092   3.939  1.00 24.63           O  
+ATOM    626  CB  SER D   9       0.867   5.442   5.808  1.00 26.93           C  
+ATOM    627  OG ASER D   9       2.007   6.245   5.739  0.50 29.03           O  
+ATOM    628  OG BSER D   9       1.007   4.841   4.581  0.50 24.22           O  
+ATOM    629  N   HIS D  10      -2.294   5.217   5.947  1.00 26.50           N  
+ATOM    630  CA  HIS D  10      -3.592   4.607   5.558  1.00 26.04           C  
+ATOM    631  C   HIS D  10      -4.712   5.659   5.335  1.00 27.12           C  
+ATOM    632  O   HIS D  10      -5.529   5.470   4.452  1.00 25.38           O  
+ATOM    633  CB  HIS D  10      -4.040   3.700   6.684  1.00 26.82           C  
+ATOM    634  CG  HIS D  10      -3.081   2.533   6.797  1.00 28.44           C  
+ATOM    635  ND1 HIS D  10      -3.161   1.467   5.943  1.00 29.43           N  
+ATOM    636  CD2 HIS D  10      -2.038   2.283   7.619  1.00 29.09           C  
+ATOM    637  CE1 HIS D  10      -2.262   0.580   6.224  1.00 29.68           C  
+ATOM    638  NE2 HIS D  10      -1.551   1.075   7.217  1.00 31.10           N  
+ATOM    639  N   LEU D  11      -4.698   6.696   6.137  1.00 26.92           N  
+ATOM    640  CA  LEU D  11      -5.659   7.849   6.061  1.00 27.13           C  
+ATOM    641  C   LEU D  11      -5.472   8.483   4.698  1.00 25.18           C  
+ATOM    642  O   LEU D  11      -6.498   8.607   4.001  1.00 23.92           O  
+ATOM    643  CB  LEU D  11      -5.422   8.720   7.282  1.00 27.87           C  
+ATOM    644  CG  LEU D  11      -5.903   8.262   8.632  1.00 30.73           C  
+ATOM    645  CD1 LEU D  11      -5.880   9.360   9.688  1.00 33.67           C  
+ATOM    646  CD2 LEU D  11      -7.344   7.814   8.340  1.00 33.85           C  
+ATOM    647  N   VAL D  12      -4.282   8.821   4.164  1.00 25.12           N  
+ATOM    648  CA  VAL D  12      -4.149   9.429   2.832  1.00 25.19           C  
+ATOM    649  C   VAL D  12      -4.570   8.542   1.690  1.00 25.25           C  
+ATOM    650  O   VAL D  12      -5.035   9.062   0.601  1.00 22.25           O  
+ATOM    651  CB  VAL D  12      -2.772  10.170   2.657  1.00 26.80           C  
+ATOM    652  CG1 VAL D  12      -2.612  11.109   3.835  1.00 27.26           C  
+ATOM    653  CG2 VAL D  12      -1.635   9.166   2.601  1.00 26.52           C  
+ATOM    654  N   GLU D  13      -4.358   7.237   1.849  1.00 24.01           N  
+ATOM    655  CA  GLU D  13      -4.839   6.292   0.843  1.00 28.05           C  
+ATOM    656  C   GLU D  13      -6.406   6.235   0.810  1.00 26.29           C  
+ATOM    657  O   GLU D  13      -7.027   6.132  -0.256  1.00 27.11           O  
+ATOM    658  CB  GLU D  13      -4.311   4.897   1.190  1.00 31.31           C  
+ATOM    659  CG  GLU D  13      -2.924   4.737   0.499  1.00 39.06           C  
+ATOM    660  CD  GLU D  13      -2.105   3.516   0.872  1.00 43.01           C  
+ATOM    661  OE1 GLU D  13      -2.446   2.756   1.780  1.00 44.89           O  
+ATOM    662  OE2 GLU D  13      -1.037   3.417   0.185  1.00 44.78           O  
+ATOM    663  N   ALA D  14      -6.993   6.313   1.952  1.00 24.73           N  
+ATOM    664  CA  ALA D  14      -8.494   6.361   2.088  1.00 24.44           C  
+ATOM    665  C   ALA D  14      -9.022   7.661   1.508  1.00 25.75           C  
+ATOM    666  O   ALA D  14      -9.997   7.649   0.735  1.00 22.85           O  
+ATOM    667  CB  ALA D  14      -8.865   6.204   3.538  1.00 25.79           C  
+ATOM    668  N   LEU D  15      -8.325   8.768   1.826  1.00 25.10           N  
+ATOM    669  CA  LEU D  15      -8.799  10.018   1.219  1.00 25.98           C  
+ATOM    670  C   LEU D  15      -8.692  10.050  -0.292  1.00 26.83           C  
+ATOM    671  O   LEU D  15      -9.524  10.662  -0.976  1.00 27.40           O  
+ATOM    672  CB  LEU D  15      -8.042  11.194   1.854  1.00 26.73           C  
+ATOM    673  CG  LEU D  15      -8.512  11.495   3.249  1.00 29.76           C  
+ATOM    674  CD1 LEU D  15      -7.611  12.533   3.871  1.00 31.61           C  
+ATOM    675  CD2 LEU D  15      -9.976  11.963   3.191  1.00 30.38           C  
+ATOM    676  N   TYR D  16      -7.624   9.445  -0.812  1.00 27.54           N  
+ATOM    677  CA  TYR D  16      -7.400   9.351  -2.232  1.00 27.63           C  
+ATOM    678  C   TYR D  16      -8.621   8.672  -2.891  1.00 26.86           C  
+ATOM    679  O   TYR D  16      -9.211   9.105  -3.944  1.00 26.09           O  
+ATOM    680  CB  TYR D  16      -5.990   8.638  -2.442  1.00 27.79           C  
+ATOM    681  CG  TYR D  16      -6.023   8.195  -3.895  1.00 26.69           C  
+ATOM    682  CD1 TYR D  16      -5.711   9.080  -4.914  1.00 28.90           C  
+ATOM    683  CD2 TYR D  16      -6.393   6.899  -4.215  1.00 28.25           C  
+ATOM    684  CE1 TYR D  16      -5.732   8.712  -6.279  1.00 28.09           C  
+ATOM    685  CE2 TYR D  16      -6.433   6.495  -5.563  1.00 27.06           C  
+ATOM    686  CZ  TYR D  16      -6.122   7.373  -6.525  1.00 29.11           C  
+ATOM    687  OH  TYR D  16      -6.198   6.915  -7.808  1.00 32.48           O  
+ATOM    688  N   LEU D  17      -9.070   7.552  -2.312  1.00 25.73           N  
+ATOM    689  CA  LEU D  17     -10.239   6.827  -2.891  1.00 27.08           C  
+ATOM    690  C   LEU D  17     -11.610   7.570  -2.717  1.00 25.90           C  
+ATOM    691  O   LEU D  17     -12.313   7.598  -3.692  1.00 27.72           O  
+ATOM    692  CB  LEU D  17     -10.286   5.409  -2.279  1.00 27.93           C  
+ATOM    693  CG  LEU D  17      -9.109   4.465  -2.647  1.00 29.07           C  
+ATOM    694  CD1 LEU D  17      -9.205   3.235  -1.736  1.00 30.07           C  
+ATOM    695  CD2 LEU D  17      -9.120   4.121  -4.127  1.00 29.20           C  
+ATOM    696  N   VAL D  18     -11.828   8.076  -1.554  1.00 26.58           N  
+ATOM    697  CA  VAL D  18     -13.081   8.773  -1.221  1.00 28.74           C  
+ATOM    698  C   VAL D  18     -13.177  10.127  -1.907  1.00 29.54           C  
+ATOM    699  O   VAL D  18     -14.251  10.490  -2.459  1.00 27.69           O  
+ATOM    700  CB  VAL D  18     -13.263   8.884   0.268  1.00 28.75           C  
+ATOM    701  CG1 VAL D  18     -14.461   9.725   0.825  1.00 30.08           C  
+ATOM    702  CG2 VAL D  18     -13.409   7.502   0.930  1.00 30.64           C  
+ATOM    703  N   CYS D  19     -12.086  10.868  -1.836  1.00 28.46           N  
+ATOM    704  CA  CYS D  19     -12.123  12.229  -2.437  1.00 29.31           C  
+ATOM    705  C   CYS D  19     -12.031  12.125  -3.909  1.00 30.54           C  
+ATOM    706  O   CYS D  19     -12.611  13.100  -4.490  1.00 33.67           O  
+ATOM    707  CB  CYS D  19     -11.165  13.257  -1.788  1.00 25.94           C  
+ATOM    708  SG  CYS D  19     -11.294  13.268  -0.072  1.00 30.76           S  
+ATOM    709  N   GLY D  20     -11.383  11.164  -4.575  1.00 31.86           N  
+ATOM    710  CA  GLY D  20     -11.367  11.168  -6.034  1.00 32.02           C  
+ATOM    711  C   GLY D  20     -10.832  12.479  -6.619  1.00 36.21           C  
+ATOM    712  O   GLY D  20      -9.807  13.113  -6.237  1.00 34.48           O  
+ATOM    713  N   GLU D  21     -11.542  12.882  -7.679  1.00 38.71           N  
+ATOM    714  CA  GLU D  21     -11.256  14.110  -8.464  1.00 40.11           C  
+ATOM    715  C   GLU D  21     -11.400  15.382  -7.663  1.00 40.77           C  
+ATOM    716  O   GLU D  21     -10.704  16.381  -8.052  1.00 41.05           O  
+ATOM    717  CB  GLU D  21     -11.866  14.000  -9.860  1.00 41.71           C  
+ATOM    718  CG AGLU D  21     -11.727  12.739 -10.679  0.50 42.09           C  
+ATOM    719  CG BGLU D  21     -10.913  14.183 -11.027  0.50 41.74           C  
+ATOM    720  CD AGLU D  21     -11.944  11.299 -10.404  0.50 42.43           C  
+ATOM    721  CD BGLU D  21     -10.049  13.164 -11.678  0.50 42.49           C  
+ATOM    722  OE1AGLU D  21     -12.701  10.706  -9.649  0.50 42.04           O  
+ATOM    723  OE1BGLU D  21     -10.485  11.983 -11.678  0.50 41.46           O  
+ATOM    724  OE2AGLU D  21     -11.183  10.565 -11.120  0.50 43.67           O  
+ATOM    725  OE2BGLU D  21      -8.971  13.445 -12.229  0.50 42.20           O  
+ATOM    726  N   ARG D  22     -12.100  15.383  -6.540  1.00 39.98           N  
+ATOM    727  CA  ARG D  22     -12.199  16.570  -5.708  1.00 41.38           C  
+ATOM    728  C   ARG D  22     -10.846  16.896  -5.077  1.00 41.75           C  
+ATOM    729  O   ARG D  22     -10.561  18.105  -4.889  1.00 44.26           O  
+ATOM    730  CB  ARG D  22     -13.293  16.530  -4.638  1.00 42.41           C  
+ATOM    731  CG  ARG D  22     -14.723  16.613  -5.173  1.00 43.39           C  
+ATOM    732  CD  ARG D  22     -15.702  15.968  -4.245  1.00 45.24           C  
+ATOM    733  NE  ARG D  22     -15.729  16.643  -2.972  1.00 47.51           N  
+ATOM    734  CZ  ARG D  22     -16.257  16.358  -1.792  1.00 49.14           C  
+ATOM    735  NH1 ARG D  22     -16.931  15.208  -1.579  1.00 50.71           N  
+ATOM    736  NH2 ARG D  22     -16.147  17.199  -0.744  1.00 49.33           N  
+ATOM    737  N   GLY D  23     -10.014  15.911  -4.711  1.00 39.69           N  
+ATOM    738  CA  GLY D  23      -8.715  16.209  -4.100  1.00 36.03           C  
+ATOM    739  C   GLY D  23      -8.940  16.464  -2.635  1.00 33.42           C  
+ATOM    740  O   GLY D  23     -10.088  16.440  -2.129  1.00 35.22           O  
+ATOM    741  N   PHE D  24      -7.892  16.750  -1.934  1.00 29.85           N  
+ATOM    742  CA  PHE D  24      -7.873  16.996  -0.500  1.00 29.48           C  
+ATOM    743  C   PHE D  24      -6.529  17.686  -0.171  1.00 31.20           C  
+ATOM    744  O   PHE D  24      -5.564  17.695  -0.918  1.00 29.78           O  
+ATOM    745  CB  PHE D  24      -8.067  15.689   0.331  1.00 30.24           C  
+ATOM    746  CG  PHE D  24      -7.007  14.606   0.095  1.00 27.97           C  
+ATOM    747  CD1 PHE D  24      -7.062  13.772  -0.982  1.00 27.92           C  
+ATOM    748  CD2 PHE D  24      -6.000  14.490   1.020  1.00 28.97           C  
+ATOM    749  CE1 PHE D  24      -6.068  12.790  -1.207  1.00 29.50           C  
+ATOM    750  CE2 PHE D  24      -4.988  13.526   0.830  1.00 28.09           C  
+ATOM    751  CZ  PHE D  24      -5.004  12.697  -0.302  1.00 29.37           C  
+ATOM    752  N   PHE D  25      -6.528  18.209   1.006  1.00 32.92           N  
+ATOM    753  CA  PHE D  25      -5.404  18.884   1.638  1.00 35.81           C  
+ATOM    754  C   PHE D  25      -5.199  17.968   2.831  1.00 36.33           C  
+ATOM    755  O   PHE D  25      -6.174  17.556   3.480  1.00 35.85           O  
+ATOM    756  CB  PHE D  25      -5.659  20.332   2.098  1.00 36.80           C  
+ATOM    757  CG  PHE D  25      -5.493  21.346   1.016  1.00 37.48           C  
+ATOM    758  CD1 PHE D  25      -6.298  21.302  -0.111  1.00 39.65           C  
+ATOM    759  CD2 PHE D  25      -4.517  22.358   1.111  1.00 39.77           C  
+ATOM    760  CE1 PHE D  25      -6.207  22.231  -1.155  1.00 40.25           C  
+ATOM    761  CE2 PHE D  25      -4.412  23.319   0.084  1.00 40.51           C  
+ATOM    762  CZ  PHE D  25      -5.249  23.246  -1.045  1.00 40.42           C  
+ATOM    763  N   TYR D  26      -3.962  17.699   3.098  1.00 36.15           N  
+ATOM    764  CA  TYR D  26      -3.598  16.866   4.251  1.00 37.79           C  
+ATOM    765  C   TYR D  26      -2.673  17.690   5.136  1.00 40.11           C  
+ATOM    766  O   TYR D  26      -1.625  18.194   4.722  1.00 40.80           O  
+ATOM    767  CB  TYR D  26      -3.014  15.501   3.767  1.00 35.67           C  
+ATOM    768  CG  TYR D  26      -2.659  14.727   5.017  1.00 35.09           C  
+ATOM    769  CD1 TYR D  26      -3.723  14.077   5.689  1.00 36.12           C  
+ATOM    770  CD2 TYR D  26      -1.357  14.565   5.461  1.00 34.78           C  
+ATOM    771  CE1 TYR D  26      -3.465  13.360   6.860  1.00 35.81           C  
+ATOM    772  CE2 TYR D  26      -1.080  13.863   6.619  1.00 34.39           C  
+ATOM    773  CZ  TYR D  26      -2.140  13.268   7.287  1.00 36.64           C  
+ATOM    774  OH  TYR D  26      -1.930  12.544   8.431  1.00 39.13           O  
+ATOM    775  N   THR D  27      -3.115  17.860   6.346  1.00 45.12           N  
+ATOM    776  CA  THR D  27      -2.443  18.631   7.376  1.00 50.91           C  
+ATOM    777  C   THR D  27      -2.434  17.890   8.721  1.00 53.86           C  
+ATOM    778  O   THR D  27      -3.399  17.928   9.523  1.00 55.65           O  
+ATOM    779  CB  THR D  27      -3.057  20.077   7.585  1.00 50.98           C  
+ATOM    780  OG1 THR D  27      -4.269  19.813   8.372  1.00 53.31           O  
+ATOM    781  CG2 THR D  27      -3.435  20.861   6.330  1.00 51.80           C  
+ATOM    782  N   PRO D  28      -1.293  17.265   8.956  1.00 56.47           N  
+ATOM    783  CA  PRO D  28      -1.045  16.518  10.188  1.00 58.63           C  
+ATOM    784  C   PRO D  28      -1.520  17.219  11.465  1.00 60.97           C  
+ATOM    785  O   PRO D  28      -1.850  16.556  12.493  1.00 61.67           O  
+ATOM    786  CB  PRO D  28       0.484  16.334  10.141  1.00 58.46           C  
+ATOM    787  CG  PRO D  28       0.793  16.223   8.667  1.00 57.48           C  
+ATOM    788  CD  PRO D  28      -0.151  17.214   8.017  1.00 56.77           C  
+ATOM    789  N   LYS D  29      -1.554  18.544  11.425  1.00 62.40           N  
+ATOM    790  CA  LYS D  29      -1.981  19.373  12.572  1.00 63.80           C  
+ATOM    791  C   LYS D  29      -3.211  20.231  12.294  1.00 64.94           C  
+ATOM    792  O   LYS D  29      -4.406  19.951  12.567  1.00 65.66           O  
+ATOM    793  CB  LYS D  29      -0.808  20.276  12.955  1.00 63.98           C  
+ATOM    794  N   THR D  30      -2.907  21.429  11.801  1.00 65.74           N  
+TER     795      THR D  30                                                      
+HETATM  796 ZN    ZN B  31       0.000   0.000  -7.813  0.33 31.34          ZN  
+HETATM  797  C1  TYL C 100      -8.640   4.060   7.114  1.00 60.77           C  
+HETATM  798  C2  TYL C 100      -7.843   4.249   8.244  1.00 59.71           C  
+HETATM  799  C3  TYL C 100      -8.418   4.762   9.399  1.00 59.60           C  
+HETATM  800  C4  TYL C 100      -9.780   5.086   9.412  1.00 59.35           C  
+HETATM  801  C5  TYL C 100     -10.569   4.909   8.293  1.00 59.16           C  
+HETATM  802  C6  TYL C 100     -10.000   4.380   7.143  1.00 59.83           C  
+HETATM  803  N   TYL C 100      -8.115   3.516   5.906  1.00 61.72           N  
+HETATM  804  C   TYL C 100      -8.494   2.477   5.137  1.00 62.55           C  
+HETATM  805  CM  TYL C 100      -9.777   1.734   5.415  1.00 62.92           C  
+HETATM  806  O4  TYL C 100     -10.279   5.586  10.598  1.00 57.91           O  
+HETATM  807  O   TYL C 100      -7.800   2.107   4.181  1.00 63.97           O  
+HETATM  808 ZN    ZN D  31       0.000   0.000   8.040  0.33 27.41          ZN  
+HETATM  809 CL    CL D  32       0.000   0.000  10.425  0.33 27.91          CL  
+HETATM  810  O   HOH A  22       4.082  25.088  -3.623  1.00 40.62           O  
+HETATM  811  O   HOH A  23      -1.939  19.980  -8.865  1.00 38.20           O  
+HETATM  812  O   HOH A  24       6.469  20.531  -9.758  1.00 45.32           O  
+HETATM  813  O   HOH A  25       6.991  23.663   1.599  1.00 59.27           O  
+HETATM  814  O   HOH A  26      -1.077  24.589   1.247  1.00 54.12           O  
+HETATM  815  O   HOH A  27      14.382  19.859 -10.971  1.00 60.00           O  
+HETATM  816  O   HOH A  28       6.673  23.496  -1.149  1.00 49.16           O  
+HETATM  817  O   HOH A  29       5.767  12.904 -21.417  1.00 58.08           O  
+HETATM  818  O   HOH A  30      -1.298  18.983 -19.625  1.00 67.91           O  
+HETATM  819  O   HOH A  31      -2.930  17.721 -11.481  1.00 47.41           O  
+HETATM  820  O   HOH A  32      -2.296   9.770 -15.924  1.00 69.09           O  
+HETATM  821  O   HOH A  33       5.972  26.453   0.024  1.00 84.72           O  
+HETATM  822  O   HOH A  34       3.863  25.178  -1.441  1.00 43.58           O  
+HETATM  823  O   HOH A  35       4.323  17.592 -18.254  1.00 58.92           O  
+HETATM  824  O   HOH A  36       6.672  23.781 -12.658  1.00 68.41           O  
+HETATM  825  O   HOH A  37      -4.327  22.798   4.269  1.00 84.69           O  
+HETATM  826  O   HOH A  38       1.318  22.117 -11.789  1.00 60.04           O  
+HETATM  827  O   HOH A  39       1.268  17.105 -19.903  1.00 68.53           O  
+HETATM  828  O   HOH A  40       0.761  25.890   2.552  1.00 74.86           O  
+HETATM  829  O   HOH A  41       6.523  17.455 -18.378  1.00 74.36           O  
+HETATM  830  O   HOH A  42       2.761  20.222 -15.922  1.00 74.48           O  
+HETATM  831  O   HOH A  43       9.540  15.042 -21.810  1.00 62.47           O  
+HETATM  832  O   HOH A  44      15.223  22.672  -5.089  1.00 65.27           O  
+HETATM  833  O   HOH A  45      12.172  22.332  -8.497  1.00 88.96           O  
+HETATM  834  O   HOH A  46      17.344  23.855  -9.047  1.00 83.33           O  
+HETATM  835  O   HOH A  47      16.262  15.321 -10.529  1.00 65.39           O  
+HETATM  836  O   HOH A  48      11.794  22.092 -12.605  1.00 72.10           O  
+HETATM  837  O   HOH A  49       9.086  27.400   1.236  1.00 77.98           O  
+HETATM  838  O   HOH B  32       0.000   0.000  -2.272  0.33 35.52           O  
+HETATM  839  O   HOH B  33       2.868  14.757   4.826  1.00 38.46           O  
+HETATM  840  O   HOH B  34      -1.463  18.478  -6.044  1.00 39.63           O  
+HETATM  841  O   HOH B  35      -0.728   1.188  -9.823  1.00 47.46           O  
+HETATM  842  O   HOH B  36       7.242  10.986 -10.750  1.00 40.85           O  
+HETATM  843  O   HOH B  37      16.402  10.857  -9.030  1.00 65.40           O  
+HETATM  844  O   HOH B  38      18.163   7.619  -5.690  1.00 39.29           O  
+HETATM  845  O   HOH B  39      16.311  10.110  -2.553  1.00 43.41           O  
+HETATM  846  O   HOH B  40       7.560   4.375 -14.347  1.00 48.52           O  
+HETATM  847  O   HOH B  41      -3.821   3.551  -6.872  1.00 52.39           O  
+HETATM  848  O   HOH B  42      11.140   5.046 -14.530  1.00 57.71           O  
+HETATM  849  O   HOH B  43       2.967   4.804  -9.903  1.00 33.89           O  
+HETATM  850  O   HOH B  44      -7.596  10.976  -8.355  1.00 54.69           O  
+HETATM  851  O   HOH B  45      -2.299  10.444 -10.032  1.00 49.05           O  
+HETATM  852  O   HOH B  46       4.680   5.461  -3.993  1.00 43.51           O  
+HETATM  853  O   HOH B  47       0.101  21.542   7.775  1.00 63.16           O  
+HETATM  854  O   HOH B  48       4.324  13.183  10.500  1.00 77.69           O  
+HETATM  855  O   HOH B  49      13.330  12.903 -13.037  1.00 57.29           O  
+HETATM  856  O   HOH B  50       3.832   4.377 -16.412  1.00 53.81           O  
+HETATM  857  O   HOH B  51      11.656  15.490   2.974  1.00 58.85           O  
+HETATM  858  O   HOH B  52       9.528  21.065  12.392  1.00 61.14           O  
+HETATM  859  O   HOH B  53      16.866  13.077  -6.063  1.00 81.03           O  
+HETATM  860  O   HOH B  54      13.621  11.342  -8.494  1.00 54.77           O  
+HETATM  861  O   HOH B  55      13.090   6.896 -16.164  1.00 72.01           O  
+HETATM  862  O   HOH B  56      -4.133   8.124 -12.455  1.00 71.91           O  
+HETATM  863  O   HOH B  57      11.164   2.934 -10.902  1.00 62.11           O  
+HETATM  864  O   HOH B  58      -9.342  21.978 -15.622  1.00 56.79           O  
+HETATM  865  O   HOH B  59      18.861   9.854 -12.339  1.00 76.57           O  
+HETATM  866  O   HOH B  60      -4.040  21.737 -13.000  1.00 74.55           O  
+HETATM  867  O   HOH B  61       7.322  22.916   8.531  1.00 81.82           O  
+HETATM  868  O   HOH B  62       2.527   3.685 -12.642  1.00 77.98           O  
+HETATM  869  O   HOH B  63       6.759  17.899  15.159  1.00 79.60           O  
+HETATM  870  O   HOH B  64       4.537  20.194  15.380  1.00 92.27           O  
+HETATM  871  O   HOH B  65     -10.241  19.684 -17.710  1.00 78.44           O  
+HETATM  872  O   HOH B  66       2.707   3.765  -2.023  1.00 56.14           O  
+HETATM  873  O   HOH B  67      -1.093   2.289  -2.987  1.00 67.35           O  
+HETATM  874  O   HOH B  68      -1.818   1.849 -14.887  1.00 71.53           O  
+HETATM  875  O   HOH B  69      16.857  11.812  -0.850  0.50 44.69           O  
+HETATM  876  O   HOH C 101     -20.361  12.753   4.094  1.00 37.92           O  
+HETATM  877  O   HOH C 102      -9.387  19.058   2.220  1.00 43.41           O  
+HETATM  878  O   HOH C 103      -6.936  17.411   9.849  1.00 56.51           O  
+HETATM  879  O   HOH C 104     -17.802   3.236   5.174  1.00 42.63           O  
+HETATM  880  O   HOH C 105     -15.234   2.888  16.196  1.00 68.86           O  
+HETATM  881  O   HOH C 106     -12.145   1.246  17.435  1.00 74.79           O  
+HETATM  882  O   HOH C 107     -17.117  19.264   4.441  1.00 65.80           O  
+HETATM  883  O   HOH C 108     -12.339  20.712   3.230  1.00 67.07           O  
+HETATM  884  O   HOH C 109     -13.928   2.950  18.604  1.00 79.19           O  
+HETATM  885  O   HOH C 110     -16.204   6.500  14.142  1.00 62.59           O  
+HETATM  886  O   HOH C 111     -17.669   3.847  11.745  1.00 59.84           O  
+HETATM  887  O   HOH C 112     -17.624   5.502  17.940  1.00 65.97           O  
+HETATM  888  O   HOH C 113     -15.464   5.573  19.616  1.00 57.02           O  
+HETATM  889  O   HOH C 114     -14.412  18.123   9.746  1.00 80.04           O  
+HETATM  890  O   HOH C 115     -12.325  25.441  -1.684  1.00 90.79           O  
+HETATM  891  O   HOH C 116     -13.227  12.666  17.675  1.00 73.60           O  
+HETATM  892  O   HOH C 117     -16.603  20.626   6.574  1.00 83.10           O  
+HETATM  893  O   HOH C 118     -10.586  15.732  19.777  0.50 53.05           O  
+HETATM  894  O   HOH D  33       0.415  11.923   9.691  1.00 46.33           O  
+HETATM  895  O   HOH D  34      -0.667   2.541   3.334  1.00 47.10           O  
+HETATM  896  O   HOH D  35      -8.278  12.083  -4.230  1.00 43.32           O  
+HETATM  897  O   HOH D  36      -6.474  16.764   6.529  1.00 45.59           O  
+HETATM  898  O   HOH D  37     -16.000  12.783  -2.387  1.00 55.78           O  
+HETATM  899  O   HOH D  38       5.798  11.764   6.991  1.00 54.10           O  
+HETATM  900  O   HOH D  39       8.892  12.300   7.812  1.00 59.27           O  
+HETATM  901  O   HOH D  40      -7.945  11.234  -6.114  1.00 47.29           O  
+HETATM  902  O   HOH D  41       4.531   5.179  18.216  1.00 58.60           O  
+HETATM  903  O   HOH D  42       2.051   8.715  17.583  1.00 58.24           O  
+HETATM  904  O   HOH D  43      -6.969  11.960 -10.687  1.00 62.92           O  
+HETATM  905  O   HOH D  44      -5.880   4.484  -2.151  1.00 52.93           O  
+HETATM  906  O   HOH D  45     -16.652  17.623   1.962  1.00 52.27           O  
+HETATM  907  O   HOH D  46      -5.421  24.303  12.639  1.00 68.35           O  
+HETATM  908  O   HOH D  47      -7.991  21.502  11.277  1.00 75.24           O  
+HETATM  909  O   HOH D  48      -6.644  19.922   5.807  1.00 71.85           O  
+HETATM  910  O   HOH D  49       2.259  12.941  12.955  1.00 69.94           O  
+HETATM  911  O   HOH D  50      -3.657  24.252   9.414  1.00 84.61           O  
+HETATM  912  O   HOH D  51      -0.902   2.997  13.974  1.00 57.90           O  
+HETATM  913  O   HOH D  52       0.000   0.000  17.749  0.33103.12           O  
+HETATM  914  O   HOH D  53       0.000   0.000  22.432  0.33 56.97           O  
+HETATM  915  O   HOH D  54      -3.253  23.389  16.670  1.00 84.04           O  
+HETATM  916  O   HOH D  55      -4.429   1.597   3.114  1.00 42.58           O  
+HETATM  917  O   HOH D  56     -12.035  20.356  -5.823  1.00 55.51           O  
+HETATM  918  O   HOH D  57      -0.613  21.971  16.496  1.00 76.96           O  
+HETATM  919  O   HOH D  58      -4.341   1.540   0.431  0.50 43.38           O  
+CONECT   43   76                                                                
+CONECT   49  223                                                                
+CONECT   76   43                                                                
+CONECT  154  317                                                                
+CONECT  223   49                                                                
+CONECT  243  796                                                                
+CONECT  317  154                                                                
+CONECT  452  485                                                                
+CONECT  458  617                                                                
+CONECT  485  452                                                                
+CONECT  566  708                                                                
+CONECT  617  458                                                                
+CONECT  638  808                                                                
+CONECT  708  566                                                                
+CONECT  796  243  841                                                           
+CONECT  797  798  802  803                                                      
+CONECT  798  797  799                                                           
+CONECT  799  798  800                                                           
+CONECT  800  799  801  806                                                      
+CONECT  801  800  802                                                           
+CONECT  802  797  801                                                           
+CONECT  803  797  804                                                           
+CONECT  804  803  805  807                                                      
+CONECT  805  804                                                                
+CONECT  806  800                                                                
+CONECT  807  804                                                                
+CONECT  808  638  809                                                           
+CONECT  809  808                                                                
+CONECT  841  796                                                                
+MASTER      522    0    4    6    2    0    8    6  915    4   29   10          
+END                                                                             


### PR DESCRIPTION
(for real this time)

- fix double and triple bonds
- fix incorrect bonds on complexes loaded from PDB

PDB files can contain TER records between blocks of ATOMs, and the TER records have a serial number. This causes gaps in the atom serial numbers, which causes incorrect matching from the output of bonding to the passed in complex. To fix this, the gaps of the passed in complex are removed before matching.