### PR TITLE
Process API improvements

### DIFF
--- a/nanome/_internal/_process/_process_manager.py
+++ b/nanome/_internal/_process/_process_manager.py
@@ -124,7 +124,7 @@ class _ProcessManager():
 
     def __stop_process(self, id):
         for entry in self.__running:
-            if entry.request.id == id:
+            if entry.request._id == id:
                 entry.process.terminate()
                 break
 

--- a/nanome/_internal/_process/_process_manager.py
+++ b/nanome/_internal/_process/_process_manager.py
@@ -9,18 +9,23 @@ except ImportError:
     from Queue import Queue, Empty  # python 2.x
 
 from nanome._internal._process import _ProcessEntry
-from nanome.util import Logs
+from nanome.util import Logs, IntEnum, auto
 
 POSIX = 'posix' in sys.builtin_module_names
 
 
 class _ProcessManager():
-    process_data_type_queued = 0
-    process_data_type_position_changed = 1
-    process_data_type_starting = 2
-    process_data_type_error = 3
-    process_data_type_output = 4
-    process_data_type_done = 5
+    class _DataType(IntEnum):
+        queued = auto()
+        position_changed = auto()
+        starting = auto()
+        error = auto()
+        output = auto()
+        done = auto()
+
+    class _CommandType(IntEnum):
+        start = auto()
+        stop = auto()
 
     _max_process_count = 10
 
@@ -43,43 +48,41 @@ class _ProcessManager():
 
                 count_before_exec = 1
                 for entry in self.__pending:
-                    entry.send(_ProcessManager.process_data_type_position_changed, [count_before_exec])
+                    entry.send(_ProcessManager._DataType.position_changed, [count_before_exec])
                     count_before_exec += 1
         except:
             Logs.error("Exception in process manager update:\n", traceback.format_exc())
 
     def __start_process(self):
         entry = self.__pending.popleft()
-        entry.send(_ProcessManager.process_data_type_starting, [])
+        entry.send(_ProcessManager._DataType.starting, [])
         request = entry.request
         args = [request.executable_path] + request.args
         has_text = entry.output_text
 
-        def enqueue_output(out, err, queue_out, queue_err, text):
+        def enqueue_output(pipe, queue, text):
             if text:
                 sentinel = ''
             else:
                 sentinel = b''
 
-            for line in iter(err.readline, sentinel):
-                queue_err.put(line)
-            err.close()
-            for line in iter(out.readline, sentinel):
-                queue_out.put(line)
-            out.close()
+            for line in iter(pipe.readline, sentinel):
+                queue.put(line)
+            pipe.close()
 
         try:
             entry.process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=1, cwd=request.cwd_path, universal_newlines=has_text, close_fds=POSIX)
             Logs.debug("Process started:", request.executable_path, "for session", entry.session._session_id)
         except:
             Logs.error("Couldn't execute process", request.executable_path, "Please check if executable is present and has permissions:\n", traceback.format_exc())
-            entry.send(_ProcessManager.process_data_type_done, [-1])
+            entry.send(_ProcessManager._DataType.done, [-1])
             return
         entry.stdout_queue = Queue()
         entry.stderr_queue = Queue()
-        thread = Thread(target=enqueue_output, args=(entry.process.stdout, entry.process.stderr, entry.stdout_queue, entry.stderr_queue, has_text))
-        thread.daemon = True
-        thread.start()
+        thread_out = Thread(target=enqueue_output, args=(entry.process.stdout, entry.stdout_queue, has_text), daemon=True)
+        thread_err = Thread(target=enqueue_output, args=(entry.process.stderr, entry.stderr_queue, has_text), daemon=True)
+        thread_out.start()
+        thread_err.start()
         self.__running.append(entry)
 
     def __update_process(self, entry):
@@ -104,22 +107,35 @@ class _ProcessManager():
         # error = error[entry._processed_error:]
         # entry._processed_error += len(error)
         if error:
-            entry.send(_ProcessManager.process_data_type_error, [error])
+            entry.send(_ProcessManager._DataType.error, [error])
 
         # output = output[entry._processed_output:]
         # entry._processed_output += len(output)
         if output:
-            entry.send(_ProcessManager.process_data_type_output, [output])
+            entry.send(_ProcessManager._DataType.output, [output])
 
         # Check if process finished
         return_value = entry.process.poll()
         if return_value is not None:
             # Finish process
-            entry.send(_ProcessManager.process_data_type_done, [return_value])
+            entry.send(_ProcessManager._DataType.done, [return_value])
             return False
         return True
 
-    def _received_request(self, request, session):
-        entry = _ProcessEntry(request, session)
-        self.__pending.append(entry)
-        session.send_process_data([_ProcessManager.process_data_type_queued, request])
+    def __stop_process(self, id):
+        for entry in self.__running:
+            if entry.request.id == id:
+                entry.process.terminate()
+                break
+
+    def _received_request(self, data, session):
+        type = data[0]
+        if type == _ProcessManager._CommandType.start:
+            request = data[1]
+            entry = _ProcessEntry(request, session)
+            self.__pending.append(entry)
+            session.send_process_data([_ProcessManager._DataType.queued, request])
+        elif type == _ProcessManager._CommandType.stop:
+            self.__stop_process(data[1])
+        else:
+            Logs.error("Received unknown process command type")

--- a/nanome/_internal/_process/_process_manager_instance.py
+++ b/nanome/_internal/_process/_process_manager_instance.py
@@ -32,7 +32,7 @@ class _ProcessManagerInstance():
         if type == _ProcessManager._DataType.queued:
             process = self.__pending_start.popleft()
             process.on_queued()
-            process.id = data[1].id
+            process._id = data[1].id
             self.__processes[data[1].id] = process
         elif type == _ProcessManager._DataType.position_changed:
             self.__processes[data[1]].on_queue_position_change(data[2])

--- a/nanome/_internal/_process/_process_manager_instance.py
+++ b/nanome/_internal/_process/_process_manager_instance.py
@@ -29,29 +29,33 @@ class _ProcessManagerInstance():
 
     def __received_data(self, data):
         type = data[0]
-        if type == _ProcessManager.process_data_type_queued:
+        if type == _ProcessManager._DataType.queued:
             process = self.__pending_start.popleft()
             process.on_queued()
+            process.id = data[1].id
             self.__processes[data[1].id] = process
-        elif type == _ProcessManager.process_data_type_position_changed:
+        elif type == _ProcessManager._DataType.position_changed:
             self.__processes[data[1]].on_queue_position_change(data[2])
-        elif type == _ProcessManager.process_data_type_starting:
+        elif type == _ProcessManager._DataType.starting:
             self.__processes[data[1]].on_start()
-        elif type == _ProcessManager.process_data_type_done:
+        elif type == _ProcessManager._DataType.done:
             self.__processes[data[1]].on_done(data[2])
-        elif type == _ProcessManager.process_data_type_error:
+        elif type == _ProcessManager._DataType.error:
             self.__processes[data[1]].on_error(data[2])
-        elif type == _ProcessManager.process_data_type_output:
+        elif type == _ProcessManager._DataType.output:
             self.__processes[data[1]].on_output(data[2])
         else:
             Logs.error("Received unknown process data type")
 
     def start_process(self, process, request):
         self.__pending_start.append(process)
-        self.send(request)
+        self.send(_ProcessManager._CommandType.start, request)
 
-    def send(self, data):
+    def stop_process(self, process):
+        self.send(_ProcessManager._CommandType.stop, process.id)
+
+    def send(self, type, data):
         from nanome._internal._util import _ProcData
         to_send = _ProcData()
-        to_send._data = data
+        to_send._data = [type, data]
         self.__pipe.send(to_send)

--- a/nanome/_internal/_structure/_io/_pdb/parse.py
+++ b/nanome/_internal/_structure/_io/_pdb/parse.py
@@ -125,7 +125,7 @@ def record_atom(line, line_number):
     charge_str = record_chunk_string(line, 79, 80)
     if len(charge_str) >= 1:
         record.formal_charge = int(charge_str[:1])
-        if charge_str.Length >= 2 and charge_str[1] == '-':
+        if len(charge_str) >= 2 and charge_str[1] == '-':
             record.formal_charge *= -1
     # Special cases
     if (len(record.element_symbol) <= 0):
@@ -161,7 +161,7 @@ def record_het_atom(line, line_number):
     charge_str = record_chunk_string(line, 79, 80)
     if len(charge_str) >= 1:
         record.formal_charge = int(charge_str[:1])
-        if charge_str.Length >= 2 and charge_str[1] == '-':
+        if len(charge_str) >= 2 and charge_str[1] == '-':
             record.formal_charge *= -1
     # Special cases
     if len(record.element_symbol) <= 0:

--- a/nanome/util/process.py
+++ b/nanome/util/process.py
@@ -9,7 +9,7 @@ class Process():
             self.cwd_path = None
             self.id = 0
 
-    def __init__(self):
+    def __init__(self, executable_path=None, args=None, output_text=None):
         self.on_queued = lambda: None
         self.on_queue_position_change = lambda _: None
         self.on_start = lambda: None
@@ -17,6 +17,12 @@ class Process():
         self.on_error = lambda _: None
         self.on_output = lambda _: None
         self.__request = Process._ProcessRequest()
+        if executable_path is not None:
+            self.__request.executable_path = executable_path
+        if args is not None:
+            self.__request.args = args
+        if output_text is not None:
+            self.__request.output_text = output_text
 
     @property
     def executable_path(self):
@@ -54,8 +60,15 @@ class Process():
             self.__request.encoding = None
 
     @property
-    def _id(self):
+    def id(self):
         return self.__request.id
+
+    @id.setter
+    def id(self, value):
+        self.__request.id = value
 
     def start(self):
         Process._manager.start_process(self, self.__request)
+
+    def stop(self):
+        Process._manager.stop_process(self)

--- a/nanome/util/process.py
+++ b/nanome/util/process.py
@@ -17,12 +17,13 @@ class Process():
         self.on_error = lambda _: None
         self.on_output = lambda _: None
         self.__request = Process._ProcessRequest()
+
         if executable_path is not None:
-            self.__request.executable_path = executable_path
+            self.executable_path = executable_path
         if args is not None:
-            self.__request.args = args
+            self.args = args
         if output_text is not None:
-            self.__request.output_text = output_text
+            self.output_text = output_text
 
     @property
     def executable_path(self):

--- a/nanome/util/process.py
+++ b/nanome/util/process.py
@@ -61,11 +61,11 @@ class Process():
             self.__request.encoding = None
 
     @property
-    def id(self):
+    def _id(self):
         return self.__request.id
 
-    @id.setter
-    def id(self, value):
+    @_id.setter
+    def _id(self, value):
         self.__request.id = value
 
     def start(self):


### PR DESCRIPTION
Previously Process API would not be able to read `stdout` if `stderr` was empty because `pipe.readline` blocks if pipe is empty. Solution is to split output parsing into 2 threads, one for `stdout` and one for `stderr`.

Additionally, `process.stop` was added to terminate a running process.