### PR TITLE
Export api

### DIFF
--- a/nanome/_internal/_network/_commands/_callbacks/_commands_enums.py
+++ b/nanome/_internal/_network/_commands/_callbacks/_commands_enums.py
@@ -66,6 +66,7 @@ class _Commands(__CommandEnum):
     directory_response= auto()
     file_response= auto()
     file_save_done= auto()
+    export_files_result= auto()
 
     #Macro
     get_macros_response = auto()
@@ -124,6 +125,7 @@ class _Messages(__CommandEnum):
     directory_request = auto()
     file_request = auto()
     file_save = auto()
+    export_files = auto()
 
     #Macro
     save_macro = auto()

--- a/nanome/_internal/_network/_commands/_serialization/__init__.py
+++ b/nanome/_internal/_network/_commands/_serialization/__init__.py
@@ -8,6 +8,7 @@ from ._control import _SetPluginListButton
 from ._file import _DirectoryRequest
 from ._file import _FileRequest
 from ._file import _FileSave
+from ._file import _ExportFiles
 
 from ._macro import _DeleteMacro
 from ._macro import _GetMacros

--- a/nanome/_internal/_network/_commands/_serialization/_file/__init__.py
+++ b/nanome/_internal/_network/_commands/_serialization/_file/__init__.py
@@ -3,3 +3,4 @@ from . import *
 from ._directory_request import _DirectoryRequest
 from ._file_request import _FileRequest
 from ._file_save import _FileSave
+from ._export_files import _ExportFiles

--- a/nanome/_internal/_network/_commands/_serialization/_file/_export_files.py
+++ b/nanome/_internal/_network/_commands/_serialization/_file/_export_files.py
@@ -1,0 +1,53 @@
+from nanome._internal._structure import _Complex, _Workspace
+from nanome._internal._structure._serialization import _ComplexSerializer
+from nanome._internal._util._serializers import _ArraySerializer, _TypeSerializer, _StringSerializer
+
+class _ExportFilesItem(_TypeSerializer):
+    def __init__(self):
+        self.__complex = _ComplexSerializer()
+        self.__string = _StringSerializer()
+
+    def version(self):
+        return 0
+
+    def name(self):
+        return "ExportFilesItem"
+
+    def serialize(self, version, value, context):
+        if isinstance(value, _Complex):
+            context.write_int(1)
+            context.write_using_serializer(self.__complex, value)
+        elif isinstance(value, int):
+            context.write_int(0)
+            context.write_int(value)
+        else:
+            raise TypeError('Trying to serialize an unsupported type for export files')
+
+    def deserialize(self, version, context):
+        result_type = context.read_int()
+        if result_type == 0:
+            return context.read_using_serializer(self.__string)
+        elif result_type == 1:
+            return context.read_byte_array()
+
+class _ExportFiles(_TypeSerializer):
+    def __init__(self):
+        self.__array = _ArraySerializer()
+        self.__array.set_type(_ExportFilesItem())
+
+    def version(self):
+        return 0
+
+    def name(self):
+        return "ExportFiles"
+
+    def serialize(self, version, value, context):
+        context.write_int(int(value[0]))
+        if (value[1] != None):
+            context.write_bool(True)
+            context.write_using_serializer(self.__array, value[1])
+        else:
+            context.write_bool(False)
+
+    def deserialize(self, version, context):
+        return context.read_using_serializer(self.__array)

--- a/nanome/_internal/_network/_commands/_serialization/_file/_export_files.py
+++ b/nanome/_internal/_network/_commands/_serialization/_file/_export_files.py
@@ -1,11 +1,13 @@
 from nanome._internal._structure import _Complex, _Workspace
-from nanome._internal._structure._serialization import _ComplexSerializer
-from nanome._internal._util._serializers import _ArraySerializer, _TypeSerializer, _StringSerializer
+from nanome._internal._structure._serialization import _ComplexSerializer, _AtomSerializer
+from nanome._internal._util._serializers import _ArraySerializer, _TypeSerializer, _StringSerializer, _LongSerializer, _DictionarySerializer
 
 class _ExportFilesItem(_TypeSerializer):
     def __init__(self):
         self.__complex = _ComplexSerializer()
         self.__string = _StringSerializer()
+        self.__dict = _DictionarySerializer()
+        self.__dict.set_types(_LongSerializer(), _AtomSerializer())
 
     def version(self):
         return 0
@@ -15,20 +17,27 @@ class _ExportFilesItem(_TypeSerializer):
 
     def serialize(self, version, value, context):
         if isinstance(value, _Complex):
-            context.write_int(1)
-            context.write_using_serializer(self.__complex, value)
+            context.write_byte(1)
+            subcontext = context.create_sub_context()
+            subcontext.payload["Atom"] = {}
+            subcontext.write_using_serializer(self.__complex, value)
+            context.write_using_serializer(self.__dict, subcontext.payload["Atom"])
+            context.write_bytes(subcontext.to_array())
         elif isinstance(value, int):
-            context.write_int(0)
-            context.write_int(value)
+            context.write_byte(0)
+            context.write_long(value)
         else:
             raise TypeError('Trying to serialize an unsupported type for export files')
 
     def deserialize(self, version, context):
-        result_type = context.read_int()
+        result_type = context.read_byte()
         if result_type == 0:
             return context.read_using_serializer(self.__string)
         elif result_type == 1:
-            return context.read_byte_array()
+            res = context.read_byte_array()
+            if len(res) == 0:
+                return None
+            return res
 
 class _ExportFiles(_TypeSerializer):
     def __init__(self):
@@ -42,7 +51,7 @@ class _ExportFiles(_TypeSerializer):
         return "ExportFiles"
 
     def serialize(self, version, value, context):
-        context.write_int(int(value[0]))
+        context.write_byte(int(value[0]))
         if (value[1] != None):
             context.write_bool(True)
             context.write_using_serializer(self.__array, value[1])

--- a/nanome/_internal/_network/_serialization/_serializer.py
+++ b/nanome/_internal/_network/_serialization/_serializer.py
@@ -123,6 +123,7 @@ add_command(CommandCallbacks._Commands.menu_transform_response, CommandSerialize
 add_command(CommandCallbacks._Commands.directory_response, CommandSerializers._DirectoryRequest(), CommandCallbacks._simple_callback_arg)
 add_command(CommandCallbacks._Commands.file_response, CommandSerializers._FileRequest(), CommandCallbacks._simple_callback_arg)
 add_command(CommandCallbacks._Commands.file_save_done, CommandSerializers._FileSave(), CommandCallbacks._simple_callback_arg)
+add_command(CommandCallbacks._Commands.export_files_result, CommandSerializers._ExportFiles(), CommandCallbacks._simple_callback_arg)
 
 #streams
 add_command(CommandCallbacks._Commands.stream_create_done, CommandSerializers._CreateStreamResult(), CommandCallbacks._receive_create_stream_result)
@@ -184,6 +185,7 @@ add_message(CommandCallbacks._Messages.hook_ui_callback, CommandSerializers._UIH
 add_message(CommandCallbacks._Messages.directory_request, CommandSerializers._DirectoryRequest())
 add_message(CommandCallbacks._Messages.file_request, CommandSerializers._FileRequest())
 add_message(CommandCallbacks._Messages.file_save, CommandSerializers._FileSave())
+add_message(CommandCallbacks._Messages.export_files, CommandSerializers._ExportFiles())
 add_message(CommandCallbacks._Messages.plugin_list_button_set, CommandSerializers._SetPluginListButton())
 
 #macros

--- a/nanome/api/plugin_instance.py
+++ b/nanome/api/plugin_instance.py
@@ -417,6 +417,23 @@ class PluginInstance(_PluginInstance):
         id = self._network._send(_Messages.load_file, (files, True, True), callback != None)
         self._save_callback(id, callback)
 
+    def request_export(self, format, callback, entities = None):
+        """
+        Request a file export using Nanome exporters
+        Can request either molecule or workspace export, for entities in Nanome workspace
+        or directly sent by the plugin (without begin uploaded to workspace)
+
+        :param format: File format to export
+        :type format: :class:`~nanome.util.enums.ExportFormats`
+        :param entities: Entities to export (complexes to send, or indices if referencing complexes in workspace, or a workspace, or nothing if exporting Nanome workspace)
+        :type entities: list of or unique object of type :class:`~nanome.api.structure.workspace` or :class:`~nanome.api.structure.complex`, or None, or list of or unique :class:`int`
+        """
+        if entities != None and not isinstance(entities, list):
+            entities = [entities]
+
+        id = self._network._send(_Messages.export_files, (format, entities), True)
+        self._save_callback(id, callback)
+
     @property
     def plugin_files_path(self):
         path = os.path.expanduser(config.fetch('plugin_files_path'))

--- a/nanome/util/enums.py
+++ b/nanome/util/enums.py
@@ -104,3 +104,10 @@ class VolumeVisualStyle(IntEnum):
     Mesh = 0
     FlatSurface = 1
     SmoothSurface = 2
+
+class ExportFormats(IntEnum):
+    Nanome = 0
+    PDB = 1
+    SDF = 2
+    MMCIF = 3
+    SMILES = 4


### PR DESCRIPTION
Usage:
self.request_export(nanome.util.enums.ExportFormats.SDF, self.response, [c1, c2])
or
self.request_export(nanome.util.enums.ExportFormats.Nanome, self.response)
or
self.request_export(nanome.util.enums.ExportFormats.PDB, self.response, [index1, index2, index3])
....

the callback (self.response) receives an array. Item(s) will be binary if format is Nanome or text if pdb/sdf/mmcif/smiles